### PR TITLE
Add WSGI entry for Waitress

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,14 @@ Create `.env` in the project root:
 GEMINI_API_KEY="YOUR_GOOGLE_GEMINI_KEY"
 ```
 
-### Run Locally
+### Run Locally/Production
 
 ```bash
+# Local development
 python run.py
+
+# Production
+waitress-serve --listen=0.0.0.0:8765 app:wsgi_app
 ```
 
 Browse to [http://127.0.0.1:8765](http://127.0.0.1:8765).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from .wsgi import wsgi_app

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,0 +1,1 @@
+from run import flask_app as wsgi_app


### PR DESCRIPTION
## Summary
- expose `flask_app` through `app:wsgi_app`
- explain how to run the server via Waitress

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f2f6c3fb483299c2930e5e35199cd