### PR TITLE
Remove unused index-mod template

### DIFF
--- a/app/templates/index-mod.html
+++ b/app/templates/index-mod.html
@@ -1,3 +1,0 @@
-<label for="subject-img-input" class="upload-box flex flex-col items-center justify-center p-4 rounded-lg min-h-[250px]">
-    </label>
-<input type="file" id="subject-img-input" accept="image/*" class="hidden">


### PR DESCRIPTION
## Summary
- clean up unused template `index-mod.html`
- verified no references exist and `index.html` is the page served at `/`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f2efc6da08329b80241d4cb22b4a0