### PR TITLE
Improve mask generation using YOLO segmentation

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -138,38 +138,58 @@ def make_mask(pil_img, parts_to_mask, conf_threshold=0.20):
     target_idx = [idx_map[p] for p in parts_to_mask if p in idx_map]
     if not target_idx: return None
         
-    detected_boxes = [b.xyxy[0].cpu().numpy() for b in res.boxes if int(b.cls.item()) in target_idx and b.conf.item() > conf_threshold]
-    if not detected_boxes: return None
-
-    box = detected_boxes[0]
-    center_point = np.array([[(box[0] + box[2]) / 2, (box[1] + box[3]) / 2]])
-    point_labels = np.array([1])
-    
-    sam_predictor.set_image(np.array(pil_img.convert("RGB")))
-    
-    masks, scores, _ = sam_predictor.predict(
-        point_coords=center_point,
-        point_labels=point_labels,
-        multimask_output=True,
-    )
-    if masks is None: return None
-    
-    # 'predict' may return either NumPy arrays or PyTorch tensors. Ensure we
-    # always work with NumPy for downstream OpenCV operations.
-    idx = int(np.array(scores).argmax()) if not isinstance(scores, torch.Tensor) else int(torch.argmax(scores).item())
-
-    if isinstance(masks, torch.Tensor):
-        masks_np = masks.cpu().numpy()
+    if getattr(res, "masks", None) is not None and getattr(res.masks, "data", None) is not None:
+        # If the YOLO model is a segmentation model, combine its masks directly
+        mask_data = res.masks.data
+        if isinstance(mask_data, torch.Tensor):
+            mask_data = mask_data.cpu().numpy()
+        if mask_data.ndim == 4:  # (B, C, H, W)
+            mask_data = mask_data[0]
+        combined = np.zeros(mask_data.shape[1:], dtype=np.uint8)
+        for i, cls_idx in enumerate(res.boxes.cls.tolist()):
+            if int(cls_idx) in target_idx and res.boxes.conf[i].item() > conf_threshold:
+                combined = np.maximum(combined, mask_data[i])
+        if combined.sum() > 0:
+            final_mask_np = (combined > 0).astype(np.uint8) * 255
+            if final_mask_np.shape != (pil_img.height, pil_img.width):
+                final_mask_np = cv2.resize(final_mask_np, (pil_img.width, pil_img.height), interpolation=cv2.INTER_NEAREST)
+        else:
+            final_mask_np = None
     else:
-        masks_np = np.array(masks)
+        detected_boxes = [b.xyxy[0].cpu().numpy() for b in res.boxes if int(b.cls.item()) in target_idx and b.conf.item() > conf_threshold]
+        if not detected_boxes:
+            return None
 
-    # SAM sometimes returns shape (1, N, H, W) or (N, H, W); handle both
-    if masks_np.ndim == 4:
-        best_mask = masks_np[0, idx]
-    else:
-        best_mask = masks_np[idx]
+        box = detected_boxes[0]
+        center_point = np.array([[(box[0] + box[2]) / 2, (box[1] + box[3]) / 2]])
+        point_labels = np.array([1])
 
-    final_mask_np = best_mask.astype(np.uint8) * 255
+        sam_predictor.set_image(np.array(pil_img.convert("RGB")))
+
+        masks, scores, _ = sam_predictor.predict(
+            point_coords=center_point,
+            point_labels=point_labels,
+            multimask_output=True,
+        )
+        if masks is None:
+            return None
+
+        idx = int(np.array(scores).argmax()) if not isinstance(scores, torch.Tensor) else int(torch.argmax(scores).item())
+
+        if isinstance(masks, torch.Tensor):
+            masks_np = masks.cpu().numpy()
+        else:
+            masks_np = np.array(masks)
+
+        if masks_np.ndim == 4:
+            best_mask = masks_np[0, idx]
+        else:
+            best_mask = masks_np[idx]
+
+        final_mask_np = best_mask.astype(np.uint8) * 255
+
+    if final_mask_np is None:
+        return None
     
     closed_mask_np = cv2.morphologyEx(final_mask_np, cv2.MORPH_CLOSE, np.ones((5, 5), np.uint8))
     dilated_mask_np = cv2.dilate(closed_mask_np, np.ones((10, 10), np.uint8), iterations=1)


### PR DESCRIPTION
## Summary
- handle YOLOv8 segmentation masks in `make_mask`
- fall back to SAM when segmentation masks are unavailable
- resize YOLO masks to match the original image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f3945c6ac8329ae3a2cb2bfb45060