### PR TITLE
Refactor theme toggle

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -224,7 +224,12 @@ def create_app():
     app.register_blueprint(meme_bp)
 
     @app.route('/')
-    def home(): return render_template('index.html')
+    def home():
+        return render_template('index.html')
+
+    @app.route('/explore')
+    def explore():
+        return render_template('explore.html')
 
     @app.route('/api/stickers')
     def get_stickers_api():

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,4 +1,5 @@
 import * as api from './api.js';
+import { initTheme } from './theme.js';
 
 let currentStep = 1;
 let subjectFile = null, processedSubjectBlob = null, sceneImageBlob = null, upscaledImageBlob = null, finalImageWithSwap = null;
@@ -565,7 +566,6 @@ function assignDomElements() {
 }
 
 function setupEventListeners() {
-    dom.themeToggle.addEventListener('click', toggleTheme);
     dom.resetAllBtn.addEventListener('click', resetWorkflow);
     dom.subjectImgInput.addEventListener('change', (e) => handleSubjectFile(e.target.files[0]));
     dom.prepareSubjectBtn.addEventListener('click', handlePrepareSubject);
@@ -834,30 +834,10 @@ function distance(x1, y1, x2, y2) {
     return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2));
 }
 
-function updateThemeIcon() {
-    const dark = document.documentElement.classList.contains('dark');
-    dom.themeIcon.innerHTML = dark
-        ? '<path d="M21.752 15.002A9.718 9.718 0 0112.75 22 9.75 9.75 0 013 12.25c0-3.902 2.338-7.25 5.748-8.748a.75.75 0 01.912 1.1 7.5 7.5 0 009.038 9.038.75.75 0 01.054 1.362z"/>'
-        : '<path d="M12 2.25a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM12 18a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5a.75.75 0 01.75-.75zM20.25 11.25a.75.75 0 010 1.5h-1.5a.75.75 0 010-1.5h1.5zM5.25 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h1.5A.75.75 0 015.25 12zM17.722 6.278a.75.75 0 011.06 0l1.06 1.06a.75.75 0 11-1.06 1.06l-1.06-1.06a.75.75 0 010-1.06zM6.218 17.782a.75.75 0 010 1.06l-1.06 1.06a.75.75 0 11-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zM6.218 6.218a.75.75 0 00-1.06 0l-1.06 1.06a.75.75 0 101.06 1.06l1.06-1.06a.75.75 0 000-1.06zM17.782 17.782a.75.75 0 000 1.06l1.06 1.06a.75.75 0 101.06-1.06l-1.06-1.06a.75.75 0 00-1.06 0zM12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z"/>';
-}
-
-function applySavedTheme() {
-    const saved = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const useDark = saved ? saved === 'dark' : prefersDark;
-    document.documentElement.classList.toggle('dark', useDark);
-    updateThemeIcon();
-}
-
-function toggleTheme() {
-    document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-    updateThemeIcon();
-}
 
 document.addEventListener('DOMContentLoaded', () => {
     assignDomElements();
-    applySavedTheme();
+    initTheme(dom.themeToggle, dom.themeIcon);
     setupEventListeners();
     loadStickers();
     resetWorkflow();

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,0 +1,27 @@
+export function initTheme(toggleSelector, iconSelector) {
+  const toggle = typeof toggleSelector === 'string' ? document.getElementById(toggleSelector) : toggleSelector;
+  const icon = typeof iconSelector === 'string' ? document.getElementById(iconSelector) : iconSelector;
+
+  function updateIcon() {
+    const dark = document.documentElement.classList.contains('dark');
+    icon.innerHTML = dark
+      ? '<path d="M21.752 15.002A9.718 9.718 0 0112.75 22 9.75 9.75 0 013 12.25c0-3.902 2.338-7.25 5.748-8.748a.75.75 0 01.912 1.1 7.5 7.5 0 009.038 9.038.75.75 0 01.054 1.362z"/>'
+      : '<path d="M12 2.25v1.5M12 20.25v1.5M4.219 4.219l1.06 1.06m13.442 13.442l1.06 1.06M2.25 12h1.5m16.5 0h1.5M6.28 17.72l1.06-1.06m9.32-9.32l1.06-1.06M8.625 12a3.375 3.375 0 106.75 0 3.375 3.375 0 00-6.75 0z"/>';
+  }
+
+  function applySaved() {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const useDark = saved ? saved === 'dark' : prefersDark;
+    document.documentElement.classList.toggle('dark', useDark);
+    updateIcon();
+  }
+
+  toggle.addEventListener('click', () => {
+    const isDark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    updateIcon();
+  });
+
+  applySaved();
+}

--- a/app/templates/explore.html
+++ b/app/templates/explore.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="it" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Explore Gallery</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <style>
+    body{font-family:'Inter',sans-serif;}
+    .sidebar svg,.navbar svg{stroke:currentColor}
+  </style>
+</head>
+<body class="bg-gray-900 text-gray-200">
+  <div class="flex min-h-screen">
+    <!-- Sidebar -->
+    <aside class="sidebar w-56 bg-gray-800 flex-shrink-0 hidden sm:flex flex-col py-6 px-4 space-y-4">
+      <h1 class="text-xl font-bold text-white mb-6">AI Gallery</h1>
+      <nav class="flex flex-col space-y-2">
+        <a href="{{ url_for('explore') }}" class="flex items-center gap-3 text-white font-semibold"><svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v16H4z"></path></svg>Explore</a>
+        <a href="{{ url_for('home') }}" class="flex items-center gap-3 text-gray-300 hover:text-white transition-all"><svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20v-6m0 0V4m0 10H6m6 0h6"></path></svg>Create</a>
+        <span class="flex items-center gap-3 text-gray-500 cursor-not-allowed"><svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 10h.01M12 10h.01M16 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>Chat</span>
+        <span class="flex items-center gap-3 text-gray-500 cursor-not-allowed"><svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M5.121 17.804A3 3 0 018 16h8a3 3 0 012.879 1.804M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>Account</span>
+      </nav>
+    </aside>
+
+    <!-- Main content -->
+    <div class="flex-1 flex flex-col">
+      <!-- Navbar -->
+      <header class="navbar sticky top-0 z-10 bg-gray-900/80 backdrop-blur flex items-center justify-between px-4 sm:px-6 py-3 border-b border-gray-700">
+        <form class="flex-1 max-w-md">
+          <input type="search" placeholder="Search" class="w-full bg-gray-800 border border-gray-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500" aria-label="Cerca">
+        </form>
+        <div class="flex items-center gap-4 ml-4">
+          <button id="theme-toggle" aria-label="Toggle dark mode" class="p-2 rounded-md hover:bg-gray-700 transition"><svg id="theme-icon" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"></svg></button>
+          <button class="p-2 rounded-md hover:bg-gray-700 transition" aria-label="Notifications"><svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg></button>
+        </div>
+      </header>
+
+      <main class="flex-1 overflow-y-auto p-4 sm:p-6">
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" id="gallery">
+          <!-- Cards injected by JS -->
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script type="module">
+    import { initTheme } from '{{ url_for('static', filename='js/theme.js') }}';
+    const gallery = document.getElementById('gallery');
+    for (let i = 1; i <= 12; i++) {
+      const card = document.createElement('div');
+      card.className = 'bg-gray-800 rounded-lg overflow-hidden shadow-lg transform transition-all hover:scale-105';
+      const img = document.createElement('img');
+      img.src = `https://picsum.photos/seed/${i}/600/400`;
+      img.alt = 'Immagine demo';
+      img.className = 'w-full h-40 object-cover';
+      card.appendChild(img);
+      gallery.appendChild(card);
+    }
+    initTheme('theme-toggle', 'theme-icon');
+  </script>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,6 +38,7 @@
         <header class="relative text-center py-6 bg-gray-200 dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700">
             <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-gray-800 dark:text-white">AI Face Swap <span class="text-blue-600">Studio Pro</span></h1>
             <p class="text-md text-gray-500 dark:text-gray-400 mt-1">Workflow Professionale Guidato</p>
+            <a href="{{ url_for('explore') }}" class="absolute left-4 top-4 text-sm text-blue-600 hover:underline">Galleria</a>
             <button id="theme-toggle" class="absolute right-4 top-4 p-2 rounded-md bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-400 dark:hover:bg-gray-600 transition-colors" aria-label="Attiva tema chiaro/scuro">
                 <svg id="theme-icon" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"></svg>
             </button>


### PR DESCRIPTION
## Summary
- centralize dark-mode logic into `theme.js`
- load reusable theme module in both index and explore pages
- simplify `script.js` and event setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f6b9ca0a08329b3551e462b0c9b57