### PR TITLE
Improve gallery and UI layout

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -246,6 +246,20 @@ def create_app():
             if sticker_paths: sticker_data.append({"category": category_name, "stickers": sticker_paths})
         return jsonify(sticker_data)
 
+    @app.route('/api/approved_memes')
+    def get_approved_memes():
+        gallery_dir = os.path.join(app.static_folder, 'gallery')
+        if not os.path.isdir(gallery_dir):
+            return jsonify([])
+        items = []
+        for fname in sorted(os.listdir(gallery_dir)):
+            if fname.lower().endswith(('.png', '.jpg', '.jpeg', '.webp', '.gif')):
+                items.append({
+                    'title': os.path.splitext(fname)[0],
+                    'url': url_for('static', filename=f'gallery/{fname}')
+                })
+        return jsonify(items)
+
     @app.route('/lottie_json/<path:sticker_path>')
     def get_lottie_json(sticker_path):
         try:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -23,6 +23,70 @@
     --border: #374151;
 }
 
+/* --- Componenti Base --- */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    transition: background-color 0.2s;
+}
+.btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+.btn-primary {
+    background-color: var(--accent);
+    color: #fff;
+}
+.btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+.btn-secondary {
+    background-color: var(--secondary);
+    color: #fff;
+}
+.btn-secondary:hover {
+    background-color: var(--secondary-hover);
+}
+
+#sidebar {
+    background-color: var(--card-bg);
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 0.5rem;
+}
+
+.gallery-item-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 0.25rem;
+    background-color: rgba(0, 0, 0, 0.6);
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+.gallery-item:hover .gallery-item-overlay,
+.gallery-item:focus-within .gallery-item-overlay {
+    opacity: 1;
+}
+
+#result-column .preview-container {
+    overflow: hidden;
+}
+#result-image-display,
+#meme-canvas {
+    object-fit: contain;
+    max-height: 70vh;
+}
+
 
 /* --- Stili per i Modali (Errori, Progressi) --- */
 .modal {

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -1,0 +1,63 @@
+export async function loadGallery(container) {
+  try {
+    const res = await fetch(`${window.location.origin}/api/approved_memes`);
+    const items = await res.json();
+    renderGallery(container, items);
+  } catch (err) {
+    console.error('Errore caricamento galleria', err);
+  }
+}
+
+function renderGallery(container, items) {
+  if (!container) return;
+  container.innerHTML = '';
+  items.forEach(m => {
+    const card = document.createElement('div');
+    card.className = 'relative group gallery-item';
+    const img = document.createElement('img');
+    img.src = m.url;
+    img.alt = m.title || 'meme';
+    img.className = 'w-full h-full object-cover rounded';
+    const overlay = document.createElement('div');
+    overlay.className = 'gallery-item-overlay';
+    const title = document.createElement('p');
+    title.className = 'text-xs text-white truncate';
+    title.textContent = m.title || '';
+    const actions = document.createElement('div');
+    actions.className = 'flex justify-end gap-1';
+    actions.innerHTML = `
+      <button class="copy-link p-1 hover:text-green-400" data-url="${m.url}" aria-label="Copia link">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M8 17v-2a4 4 0 014-4h8"/><path d="M16 7v2a4 4 0 01-4 4H4"/></svg>
+      </button>
+      <button class="remove-item p-1 hover:text-red-500" aria-label="Rimuovi">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M6 18L18 6M6 6l12 12"/></svg>
+      </button>`;
+    overlay.appendChild(title);
+    overlay.appendChild(actions);
+    card.appendChild(img);
+    card.appendChild(overlay);
+    container.appendChild(card);
+  });
+}
+
+export function setupGalleryInteraction(container) {
+  if (!container) return;
+  container.addEventListener('click', e => {
+    const copy = e.target.closest('.copy-link');
+    const remove = e.target.closest('.remove-item');
+    if (copy) {
+      navigator.clipboard.writeText(copy.dataset.url || '').catch(() => {});
+    } else if (remove) {
+      remove.closest('.gallery-item')?.remove();
+    }
+  });
+}
+
+export function initSidebarToggle(sidebar, toggleBtn, galleryToggle, galleryContainer) {
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => sidebar.classList.toggle('hidden'));
+  }
+  if (galleryToggle && galleryContainer) {
+    galleryToggle.addEventListener('click', () => galleryContainer.classList.toggle('hidden'));
+  }
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -3,12 +3,15 @@ import { initTheme } from './theme.js';
 import { setupEventListeners, resetWorkflow, closeModal } from './workflow.js';
 import { loadStickers } from './stickers.js';
 import { animationLoop } from './memeEditor.js';
+import { loadGallery, setupGalleryInteraction, initSidebarToggle } from './gallery.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   assignDomElements();
   initTheme(dom.themeToggle, dom.themeIcon);
+  initSidebarToggle(dom.sidebar, dom.sidebarToggle, dom.galleryToggle, dom.galleryContainer);
   setupEventListeners();
   loadStickers();
+  loadGallery(dom.galleryContainer).then(() => setupGalleryInteraction(dom.galleryContainer));
   resetWorkflow();
   animationLoop();
   window.closeModal = closeModal;

--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -46,7 +46,8 @@ export function assignDomElements() {
     'analyze-parts-btn',
     'dynamic-prompts-container',
     'generate-all-btn',
-    'theme-toggle', 'theme-icon'
+    'theme-toggle', 'theme-icon',
+    'sidebar', 'sidebar-toggle', 'gallery-toggle', 'gallery-container'
   ];
   ids.forEach(id => {
     const el = document.getElementById(id);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,11 +34,25 @@
         </div>
     </div>
 
-    <div class="flex flex-col min-h-screen">
+    <div class="flex min-h-screen">
+        <aside id="sidebar" class="hidden md:flex flex-col w-56 bg-gray-800 text-gray-200 p-4 space-y-4 border-r border-gray-700">
+            <nav class="flex flex-col gap-3 text-sm">
+                <a href="{{ url_for('explore') }}" class="hover:text-white">Esplora</a>
+                <a href="{{ url_for('home') }}" class="text-white font-semibold">Crea</a>
+                <span class="text-gray-500 cursor-not-allowed">Chat</span>
+                <span class="text-gray-500 cursor-not-allowed">Account</span>
+                <button id="gallery-toggle" class="text-left hover:text-white">Galleria</button>
+            </nav>
+            <div id="gallery-container" class="gallery-grid hidden mt-4 overflow-y-auto"></div>
+        </aside>
+
+        <div class="flex flex-col flex-1 min-h-screen">
         <header class="relative text-center py-6 bg-gray-200 dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700">
+            <button id="sidebar-toggle" class="md:hidden absolute left-4 top-4 p-2 rounded-md bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-400 dark:hover:bg-gray-600" aria-label="Apri menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
             <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-gray-800 dark:text-white">AI Face Swap <span class="text-blue-600">Studio Pro</span></h1>
             <p class="text-md text-gray-500 dark:text-gray-400 mt-1">Workflow Professionale Guidato</p>
-            <a href="{{ url_for('explore') }}" class="absolute left-4 top-4 text-sm text-blue-600 hover:underline">Galleria</a>
             <button id="theme-toggle" class="absolute right-4 top-4 p-2 rounded-md bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-400 dark:hover:bg-gray-600 transition-colors" aria-label="Attiva tema chiaro/scuro">
                 <svg id="theme-icon" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"></svg>
             </button>
@@ -214,9 +228,9 @@
 
             <div id="result-column" class="bg-gray-800 p-6 rounded-xl shadow-lg lg:sticky top-8 self-start">
                 <h2 class="text-3xl font-bold mb-6 text-center text-white">Anteprima</h2>
-                <div class="relative flex justify-center items-center mb-6 bg-gray-900 rounded-lg min-h-[400px] p-2 aspect-square">
-                    <img id="result-image-display" src="" alt="Risultato" class="rounded-lg max-w-full max-h-[80vh] h-auto shadow-md hidden z-0 object-contain">
-                    <canvas id="meme-canvas" class="hidden rounded-lg max-w-full max-h-[80vh] h-auto shadow-md object-contain"></canvas>
+                <div class="preview-container relative flex justify-center items-center mb-6 bg-gray-900 rounded-lg min-h-[400px] p-2">
+                    <img id="result-image-display" src="" alt="Risultato" class="rounded-lg max-w-full h-auto shadow-md hidden z-0 object-contain">
+                    <canvas id="meme-canvas" class="hidden rounded-lg max-w-full h-auto shadow-md object-contain"></canvas>
                     <div id="target-face-boxes-container" class="absolute top-0 left-0 w-full h-full pointer-events-none z-10"></div>
                     <p id="result-placeholder" class="text-gray-500">Il risultato del processo apparirà qui...</p>
                 </div>
@@ -241,6 +255,7 @@
                 </div>
             </div>
         </main>
+        </div>
     </div>
     
     <script type="module" src="{{ url_for('static', filename='js/main.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- add sidebar with toggleable gallery
- style buttons and sidebar
- ensure preview image doesn't overlap controls
- add gallery module and fetch server data
- expose `/api/approved_memes` endpoint
- remove sample gallery images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffc29253c832988177864a4f2df6f