### PR TITLE
Enhance gallery & explore features

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -230,7 +230,11 @@ def create_app():
 
     @app.route('/explore')
     def explore():
-        return render_template('explore.html')
+        return render_template('esplora.html')
+
+    @app.route('/gallery')
+    def gallery_page():
+        return render_template('galleria.html')
 
     @app.route('/api/stickers')
     def get_stickers_api():
@@ -259,6 +263,21 @@ def create_app():
                     'url': url_for('static', filename=f'gallery/{fname}')
                 })
         return jsonify(items)
+
+    @app.route('/api/memes')
+    def api_memes():
+        return get_approved_memes()
+
+    @app.route('/api/meme', methods=['POST'])
+    def api_add_meme():
+        if 'image' not in request.files:
+            return jsonify({'error': 'Immagine mancante'}), 400
+        file = request.files['image']
+        fname = uuid.uuid4().hex + os.path.splitext(file.filename)[1]
+        save_path = os.path.join(app.static_folder, 'gallery', fname)
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        file.save(save_path)
+        return jsonify({'url': url_for('static', filename=f'gallery/{fname}')})
 
     @app.route('/lottie_json/<path:sticker_path>')
     def get_lottie_json(sticker_path):

--- a/app/static/js/facebox.js
+++ b/app/static/js/facebox.js
@@ -1,0 +1,73 @@
+import { state, dom } from './state.js';
+import * as api from './api.js';
+import { showError } from './workflow.js';
+
+export function drawFaceBoxes(container, image, faces, type) {
+  if (!container || !image || !image.complete || image.naturalWidth === 0) return;
+  container.innerHTML = '';
+  const rect = image.getBoundingClientRect();
+  if (!rect.width) return;
+  const scaleX = rect.width / image.naturalWidth;
+  const scaleY = rect.height / image.naturalHeight;
+  faces.forEach((face, idx) => {
+    const [x1, y1, x2, y2] = face.bbox;
+    const box = document.createElement('div');
+    box.className = 'face-box';
+    box.style.left = `${x1 * scaleX}px`;
+    box.style.top = `${y1 * scaleY}px`;
+    box.style.width = `${(x2 - x1) * scaleX}px`;
+    box.style.height = `${(y2 - y1) * scaleY}px`;
+    const label = document.createElement('span');
+    label.className = 'face-box-label';
+    label.textContent = idx + 1;
+    box.appendChild(label);
+    box.onclick = e => { e.stopPropagation(); handleFaceSelection(idx, type); };
+    container.appendChild(box);
+  });
+}
+
+export function updateSelectionHighlights(container, selectedIndex) {
+  if (!container) return;
+  container.querySelectorAll('.face-box').forEach((b,i)=>b.classList.toggle('selected', i===selectedIndex));
+}
+
+export function refreshFaceBoxes() {
+  drawFaceBoxes(dom.sourceFaceBoxesContainer, dom.sourceImgPreview, state.sourceFaces, 'source');
+  drawFaceBoxes(dom.targetFaceBoxesContainer, dom.resultImageDisplay, state.targetFaces, 'target');
+}
+
+export async function detectAndDrawFaces(blob, image, container, faces, type) {
+  const onLoad = async () => {
+    try {
+      const data = await api.detectFaces(blob);
+      faces.splice(0, faces.length, ...data.faces);
+      drawFaceBoxes(container, image, faces, type);
+      updateSelectionHighlights(container, type==='source'?state.selectedSourceIndex:state.selectedTargetIndex);
+    } catch (err) {
+      showError('Errore Rilevamento Volti', err.message);
+      faces.length = 0;
+      drawFaceBoxes(container, image, [], type);
+    }
+  };
+  if (image.complete && image.naturalWidth > 0) onLoad();
+  else image.onload = onLoad;
+}
+
+function handleFaceSelection(index, type) {
+  if (type === 'source') {
+    state.selectedSourceIndex = index;
+  } else {
+    state.selectedTargetIndex = index;
+  }
+  updateSelectionHighlights(type==='source'?dom.sourceFaceBoxesContainer:dom.targetFaceBoxesContainer, index);
+  dom.selectionStatus.classList.remove('hidden');
+  dom.selectedSourceId.textContent = state.selectedSourceIndex + 1 || 'Nessuno';
+  dom.selectedTargetId.textContent = state.selectedTargetIndex + 1 || 'Nessuno';
+  dom.swapBtn.disabled = state.selectedSourceIndex < 0 || state.selectedTargetIndex < 0;
+}
+
+if (window.ResizeObserver) {
+  const ro = new ResizeObserver(refreshFaceBoxes);
+  [dom.resultImageDisplay, dom.sourceImgPreview].forEach(el=>el && ro.observe(el));
+}
+window.addEventListener('resize', refreshFaceBoxes);

--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -4,6 +4,7 @@ import { updateMemePreview, handleDownloadAnimation } from './memeEditor.js';
 import { getStickerAtPosition } from './stickers.js';
 import { addToGallery } from './gallery.js';
 
+import { drawFaceBoxes, updateSelectionHighlights, refreshFaceBoxes, detectAndDrawFaces } from "./facebox.js";
 export function displayImage(imageBlobOrFile, imageElement) {
   if (!imageBlobOrFile || !imageElement) return;
   const oldUrl = imageElement.src;
@@ -22,43 +23,6 @@ export function displayImage(imageBlobOrFile, imageElement) {
   }
 }
 
-export function drawFaceBoxes(boxesContainer, imageElement, faceArray, selectionType) {
-  if (!boxesContainer || !imageElement || !imageElement.complete || imageElement.naturalWidth === 0) return;
-  boxesContainer.innerHTML = '';
-  const rect = imageElement.getBoundingClientRect();
-  if (rect.width === 0) return;
-  const parentRect = boxesContainer.getBoundingClientRect();
-  const scaleX = rect.width / imageElement.naturalWidth;
-  const scaleY = rect.height / imageElement.naturalHeight;
-  const offsetX = rect.left - parentRect.left;
-  const offsetY = rect.top - parentRect.top;
-  faceArray.forEach((face, index) => {
-    const [x1, y1, x2, y2] = face.bbox;
-    const box = document.createElement('div');
-    box.className = 'face-box';
-    box.style.left = `${offsetX + x1 * scaleX}px`;
-    box.style.top = `${offsetY + y1 * scaleY}px`;
-    box.style.width = `${(x2 - x1) * scaleX}px`;
-    box.style.height = `${(y2 - y1) * scaleY}px`;
-    box.style.pointerEvents = 'auto';
-    const label = document.createElement('span');
-    label.className = 'face-box-label';
-    label.textContent = index + 1;
-    box.appendChild(label);
-    box.onclick = e => { e.stopPropagation(); handleFaceSelection(index, selectionType); };
-    boxesContainer.appendChild(box);
-  });
-}
-
-export function updateSelectionHighlights(container, selectedIndex) {
-  if (!container) return;
-  container.querySelectorAll('.face-box').forEach((box, i) => box.classList.toggle('selected', i === selectedIndex));
-}
-
-export function refreshFaceBoxes() {
-  drawFaceBoxes(dom.sourceFaceBoxesContainer, dom.sourceImgPreview, state.sourceFaces, 'source');
-  drawFaceBoxes(dom.targetFaceBoxesContainer, dom.resultImageDisplay, state.targetFaces, 'target');
-}
 
 export function startProgressBar(title, duration = 30) {
   dom.progressTitle.textContent = title;
@@ -98,40 +62,6 @@ export function goToStep(stepNumber) {
   const stepId = `step-${stepNumber}-${['subject', 'scene', 'upscale', 'finalize'][stepNumber - 1]}`;
   document.getElementById(stepId)?.classList.remove('hidden');
 }
-
-export async function detectAndDrawFaces(imageBlob, imageElement, boxesContainer, faceArray, selectionType) {
-  const onImageLoad = async () => {
-    try {
-      const data = await api.detectFaces(imageBlob);
-      faceArray.splice(0, faceArray.length, ...data.faces);
-      drawFaceBoxes(boxesContainer, imageElement, faceArray, selectionType);
-      updateSelectionHighlights(boxesContainer, selectionType === 'source' ? state.selectedSourceIndex : state.selectedTargetIndex);
-    } catch (err) {
-      showError('Errore Rilevamento Volti', err.message);
-      faceArray.length = 0;
-      drawFaceBoxes(boxesContainer, imageElement, [], selectionType);
-    }
-  };
-  if (imageElement.complete && imageElement.naturalWidth > 0) {
-    onImageLoad();
-  } else {
-    imageElement.onload = onImageLoad;
-  }
-}
-
-export function handleFaceSelection(index, type) {
-  if (type === 'source') {
-    state.selectedSourceIndex = state.selectedSourceIndex === index ? -1 : index;
-  } else {
-    state.selectedTargetIndex = state.selectedTargetIndex === index ? -1 : index;
-  }
-  dom.selectedSourceId.textContent = state.selectedSourceIndex > -1 ? `#${state.selectedSourceIndex + 1}` : 'Nessuno';
-  dom.selectedTargetId.textContent = state.selectedTargetIndex > -1 ? `#${state.selectedTargetIndex + 1}` : 'Nessuno';
-  updateSelectionHighlights(dom.sourceFaceBoxesContainer, state.selectedSourceIndex);
-  updateSelectionHighlights(dom.targetFaceBoxesContainer, state.selectedTargetIndex);
-  dom.swapBtn.disabled = !(state.selectedSourceIndex > -1 && state.selectedTargetIndex > -1);
-}
-
 export function handleSubjectFile(file) {
   if (!file?.type.startsWith('image/')) return;
   state.subjectFile = file;
@@ -433,10 +363,11 @@ export function setupEventListeners() {
     link.click();
   });
   dom.addGalleryBtn.addEventListener('click', () => {
-    const src = dom.memeCanvas.classList.contains('hidden') ? dom.resultImageDisplay.src : dom.memeCanvas.toDataURL('image/png');
+    updateMemePreview();
+    const src = dom.memeCanvas.toDataURL('image/png');
     const list = JSON.parse(localStorage.getItem('userGallery') || '[]');
     const title = `Meme #${list.length + 1}`;
-    addToGallery(title, src);
+    addToGallery(title, src, dom.captionTextInput.value);
   });
   dom.downloadAnimBtn.addEventListener('click', handleDownloadAnimation);
   const getCoords = e => {

--- a/app/templates/esplora.html
+++ b/app/templates/esplora.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Esplora</title>
+  <script src="https://cdn.tailwindcss.com" defer></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <style>body{font-family:'Inter',sans-serif}</style>
+</head>
+<body class="bg-gray-900 text-gray-200">
+  <header class="sticky top-0 z-10 flex items-center justify-between p-4 bg-gray-800 shadow">
+    <h1 class="text-xl font-semibold">Esplora</h1>
+    <div class="flex items-center gap-2">
+      <a href="{{ url_for('gallery_page') }}" class="text-sm hover:underline">Galleria</a>
+      <a href="{{ url_for('home') }}" class="text-sm hover:underline">Crea</a>
+      <button id="theme-toggle" aria-label="Toggle theme" class="p-2 rounded-md hover:bg-gray-700"><svg id="theme-icon" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"></svg></button>
+    </div>
+  </header>
+  <main class="p-4">
+    <input type="search" id="explore-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca immagini">
+    <div id="explore-grid" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
+    <div id="sentinel" class="h-10"></div>
+  </main>
+  <div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="gallery-modal-img">
+    <div class="flex items-center justify-center min-h-screen px-4">
+      <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg p-4 shadow-2xl max-w-3xl mx-auto">
+        <img id="gallery-modal-img" src="" alt="Anteprima" class="max-h-[80vh] mx-auto rounded-lg" />
+        <div class="mt-4 flex justify-end gap-2">
+          <a id="gallery-download" href="#" download="meme.png" class="btn btn-primary">Download</a>
+          <button type="button" onclick="closeModal('gallery-modal')" class="btn bg-gray-700">Chiudi</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script type="module">
+    import { initTheme } from '{{ url_for('static', filename='js/theme.js') }}';
+    import { loadExplore } from '{{ url_for('static', filename='js/gallery.js') }}';
+    import { closeModal } from '{{ url_for('static', filename='js/workflow.js') }}';
+    const grid = document.getElementById('explore-grid');
+    const searchInput = document.getElementById('explore-search');
+    let filter = '';
+    const { fetchMore, applyFilter } = await loadExplore(grid);
+    const obs = new IntersectionObserver(entries=>{ if(entries[0].isIntersecting) fetchMore(); });
+    obs.observe(document.getElementById('sentinel'));
+    searchInput.addEventListener('input', e=>{ filter = e.target.value.toLowerCase(); applyFilter(filter); });
+    window.addEventListener('gallery-updated', ()=>{ applyFilter(filter, true); });
+    initTheme('theme-toggle','theme-icon');
+    window.closeModal = closeModal;
+  </script>
+</body>
+</html>

--- a/app/templates/galleria.html
+++ b/app/templates/galleria.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Galleria</title>
+  <script src="https://cdn.tailwindcss.com" defer></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <style>body{font-family:'Inter',sans-serif}</style>
+</head>
+<body class="bg-gray-900 text-gray-200">
+  <header class="sticky top-0 z-10 flex items-center justify-between p-4 bg-gray-800 shadow">
+    <h1 class="text-xl font-semibold">Galleria</h1>
+    <div class="flex items-center gap-2">
+      <a href="{{ url_for('explore') }}" class="text-sm hover:underline">Esplora</a>
+      <a href="{{ url_for('home') }}" class="text-sm hover:underline">Crea</a>
+      <button id="theme-toggle" aria-label="Toggle theme" class="p-2 rounded-md hover:bg-gray-700"><svg id="theme-icon" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"></svg></button>
+    </div>
+  </header>
+  <main class="p-4">
+    <input type="search" id="gallery-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca nella galleria">
+    <div id="user-gallery" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
+  </main>
+  <div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="gallery-modal-img">
+    <div class="flex items-center justify-center min-h-screen px-4">
+      <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg p-4 shadow-2xl max-w-3xl mx-auto">
+        <img id="gallery-modal-img" src="" alt="Anteprima" class="max-h-[80vh] mx-auto rounded-lg" />
+        <div class="mt-4 flex justify-end gap-2">
+          <a id="gallery-download" href="#" download="meme.png" class="btn btn-primary">Download</a>
+          <button type="button" onclick="closeModal('gallery-modal')" class="btn bg-gray-700">Chiudi</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div id="toast" class="fixed bottom-4 right-4 bg-gray-800 text-white px-3 py-2 rounded shadow hidden"></div>
+  <script type="module">
+    import { initTheme } from '{{ url_for('static', filename='js/theme.js') }}';
+    import { loadGallery, setupGalleryInteraction } from '{{ url_for('static', filename='js/gallery.js') }}';
+    import { closeModal } from '{{ url_for('static', filename='js/workflow.js') }}';
+    const container = document.getElementById('user-gallery');
+    const searchInput = document.getElementById('gallery-search');
+    function render() { loadGallery(container).then(()=>setupGalleryInteraction(container)); }
+    render();
+    window.addEventListener('gallery-updated', render);
+    searchInput.addEventListener('input', e=>{
+      const t = e.target.value.toLowerCase();
+      container.querySelectorAll('.gallery-item').forEach(card=>{
+        const txt = card.querySelector('p')?.textContent.toLowerCase() || '';
+        card.style.display = txt.includes(t) ? '' : 'none';
+      });
+    });
+    initTheme('theme-toggle','theme-icon');
+    window.closeModal = closeModal;
+  </script>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -247,7 +247,7 @@
                 <div class="flex justify-center items-center gap-2 flex-wrap">
                     <a id="download-btn" href="#" download="pro-meme-result-static.png" class="hidden items-center bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica PNG</a>
 
-                    <button id="add-gallery-btn" class="hidden items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
+                    <button id="add-gallery-btn" class="hidden fixed bottom-4 right-4 z-20 items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
                     
                     <button id="download-anim-btn" class="hidden items-center bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica Animato</button>
                     <select id="anim-fmt" class="hidden bg-gray-700 text-sm text-white rounded-full px-3 py-2 shadow-lg cursor-pointer">
@@ -269,6 +269,7 @@
         </div>
     </div>
     
+<div id="toast" class="fixed bottom-20 right-4 bg-gray-800 text-white px-3 py-2 rounded shadow hidden"></div>
     <script type="module" src="{{ url_for('static', filename='js/main.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create dedicated Galleria and Esplora pages
- add facebox.js for persistent face selection overlay
- sync gallery with explore and implement infinite scroll & search
- embed caption text before saving memes and show toast on save
- add REST endpoints for future gallery API
- quick save button floats on screen

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685009406688832995f0c1d411c1da3c