### PR TITLE
Enhance layout and restore image loading

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -230,7 +230,11 @@ def create_app():
 
     @app.route('/explore')
     def explore():
-        return render_template('explore.html')
+        return render_template('esplora.html')
+
+    @app.route('/gallery')
+    def gallery_page():
+        return render_template('galleria.html')
 
     @app.route('/api/stickers')
     def get_stickers_api():
@@ -259,6 +263,21 @@ def create_app():
                     'url': url_for('static', filename=f'gallery/{fname}')
                 })
         return jsonify(items)
+
+    @app.route('/api/memes')
+    def api_memes():
+        return get_approved_memes()
+
+    @app.route('/api/meme', methods=['POST'])
+    def api_add_meme():
+        if 'image' not in request.files:
+            return jsonify({'error': 'Immagine mancante'}), 400
+        file = request.files['image']
+        fname = uuid.uuid4().hex + os.path.splitext(file.filename)[1]
+        save_path = os.path.join(app.static_folder, 'gallery', fname)
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        file.save(save_path)
+        return jsonify({'url': url_for('static', filename=f'gallery/{fname}')})
 
     @app.route('/lottie_json/<path:sticker_path>')
     def get_lottie_json(sticker_path):

--- a/app/static/js/facebox.js
+++ b/app/static/js/facebox.js
@@ -1,0 +1,73 @@
+import { state, dom } from './state.js';
+import * as api from './api.js';
+import { showError } from './workflow.js';
+
+export function drawFaceBoxes(container, image, faces, type) {
+  if (!container || !image || !image.complete || image.naturalWidth === 0) return;
+  container.innerHTML = '';
+  const rect = image.getBoundingClientRect();
+  if (!rect.width) return;
+  const scaleX = rect.width / image.naturalWidth;
+  const scaleY = rect.height / image.naturalHeight;
+  faces.forEach((face, idx) => {
+    const [x1, y1, x2, y2] = face.bbox;
+    const box = document.createElement('div');
+    box.className = 'face-box';
+    box.style.left = `${x1 * scaleX}px`;
+    box.style.top = `${y1 * scaleY}px`;
+    box.style.width = `${(x2 - x1) * scaleX}px`;
+    box.style.height = `${(y2 - y1) * scaleY}px`;
+    const label = document.createElement('span');
+    label.className = 'face-box-label';
+    label.textContent = idx + 1;
+    box.appendChild(label);
+    box.onclick = e => { e.stopPropagation(); handleFaceSelection(idx, type); };
+    container.appendChild(box);
+  });
+}
+
+export function updateSelectionHighlights(container, selectedIndex) {
+  if (!container) return;
+  container.querySelectorAll('.face-box').forEach((b,i)=>b.classList.toggle('selected', i===selectedIndex));
+}
+
+export function refreshFaceBoxes() {
+  drawFaceBoxes(dom.sourceFaceBoxesContainer, dom.sourceImgPreview, state.sourceFaces, 'source');
+  drawFaceBoxes(dom.targetFaceBoxesContainer, dom.resultImageDisplay, state.targetFaces, 'target');
+}
+
+export async function detectAndDrawFaces(blob, image, container, faces, type) {
+  const onLoad = async () => {
+    try {
+      const data = await api.detectFaces(blob);
+      faces.splice(0, faces.length, ...data.faces);
+      drawFaceBoxes(container, image, faces, type);
+      updateSelectionHighlights(container, type==='source'?state.selectedSourceIndex:state.selectedTargetIndex);
+    } catch (err) {
+      showError('Errore Rilevamento Volti', err.message);
+      faces.length = 0;
+      drawFaceBoxes(container, image, [], type);
+    }
+  };
+  if (image.complete && image.naturalWidth > 0) onLoad();
+  else image.onload = onLoad;
+}
+
+function handleFaceSelection(index, type) {
+  if (type === 'source') {
+    state.selectedSourceIndex = index;
+  } else {
+    state.selectedTargetIndex = index;
+  }
+  updateSelectionHighlights(type==='source'?dom.sourceFaceBoxesContainer:dom.targetFaceBoxesContainer, index);
+  dom.selectionStatus.classList.remove('hidden');
+  dom.selectedSourceId.textContent = state.selectedSourceIndex + 1 || 'Nessuno';
+  dom.selectedTargetId.textContent = state.selectedTargetIndex + 1 || 'Nessuno';
+  dom.swapBtn.disabled = state.selectedSourceIndex < 0 || state.selectedTargetIndex < 0;
+}
+
+if (window.ResizeObserver) {
+  const ro = new ResizeObserver(refreshFaceBoxes);
+  [dom.resultImageDisplay, dom.sourceImgPreview].forEach(el=>el && ro.observe(el));
+}
+window.addEventListener('resize', refreshFaceBoxes);

--- a/app/templates/esplora.html
+++ b/app/templates/esplora.html
@@ -1,0 +1,36 @@
+{% extends 'layout.html' %}
+{% block title %}Esplora{% endblock %}
+{% block header_title %}Esplora{% endblock %}
+{% block content %}
+<div class="p-4">
+  <input type="search" id="explore-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca immagini">
+  <div id="explore-grid" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
+  <div id="sentinel" class="h-10"></div>
+</div>
+<div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="gallery-modal-img">
+  <div class="flex items-center justify-center min-h-screen px-4">
+    <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg p-4 shadow-2xl max-w-3xl mx-auto">
+      <img id="gallery-modal-img" src="" alt="Anteprima" class="max-h-[80vh] mx-auto rounded-lg" />
+      <div class="mt-4 flex justify-end gap-2">
+        <a id="gallery-download" href="#" download="meme.png" class="btn btn-primary">Download</a>
+        <button type="button" onclick="closeModal('gallery-modal')" class="btn bg-gray-700">Chiudi</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script type="module">
+  import { loadExplore } from '{{ url_for('static', filename='js/gallery.js') }}';
+  import { closeModal } from '{{ url_for('static', filename='js/workflow.js') }}';
+  const grid = document.getElementById('explore-grid');
+  const searchInput = document.getElementById('explore-search');
+  let filter = '';
+  const { fetchMore, applyFilter } = await loadExplore(grid);
+  const obs = new IntersectionObserver(entries=>{ if(entries[0].isIntersecting) fetchMore(); });
+  obs.observe(document.getElementById('sentinel'));
+  searchInput.addEventListener('input', e=>{ filter = e.target.value.toLowerCase(); applyFilter(filter); });
+  window.addEventListener('gallery-updated', ()=>{ applyFilter(filter, true); });
+  window.closeModal = closeModal;
+</script>
+{% endblock %}

--- a/app/templates/galleria.html
+++ b/app/templates/galleria.html
@@ -1,0 +1,40 @@
+{% extends 'layout.html' %}
+{% block title %}Galleria{% endblock %}
+{% block header_title %}Galleria{% endblock %}
+{% block content %}
+<div class="p-4">
+  <input type="search" id="gallery-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca nella galleria">
+  <div id="user-gallery" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
+</div>
+<div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="gallery-modal-img">
+  <div class="flex items-center justify-center min-h-screen px-4">
+    <div class="modal-content bg-gray-900 border border-gray-700 rounded-lg p-4 shadow-2xl max-w-3xl mx-auto">
+      <img id="gallery-modal-img" src="" alt="Anteprima" class="max-h-[80vh] mx-auto rounded-lg" />
+      <div class="mt-4 flex justify-end gap-2">
+        <a id="gallery-download" href="#" download="meme.png" class="btn btn-primary">Download</a>
+        <button type="button" onclick="closeModal('gallery-modal')" class="btn bg-gray-700">Chiudi</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="toast" class="fixed bottom-4 right-4 bg-gray-800 text-white px-3 py-2 rounded shadow hidden"></div>
+{% endblock %}
+{% block scripts %}
+<script type="module">
+  import { loadGallery, setupGalleryInteraction } from '{{ url_for('static', filename='js/gallery.js') }}';
+  import { closeModal } from '{{ url_for('static', filename='js/workflow.js') }}';
+  const container = document.getElementById('user-gallery');
+  const searchInput = document.getElementById('gallery-search');
+  function render(){ loadGallery(container).then(()=>setupGalleryInteraction(container)); }
+  render();
+  window.addEventListener('gallery-updated', render);
+  searchInput.addEventListener('input', e=>{
+    const t = e.target.value.toLowerCase();
+    container.querySelectorAll('.gallery-item').forEach(card=>{
+      const txt = card.querySelector('p')?.textContent.toLowerCase() || '';
+      card.style.display = txt.includes(t) ? '' : 'none';
+    });
+  });
+  window.closeModal = closeModal;
+</script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html lang="it" class="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Face Swap Studio Pro</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body class="antialiased bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-300">
+{% extends 'layout.html' %}
+{% block title %}AI Face Swap Studio Pro{% endblock %}
+{% block header_title %}AI Face Swap <span class="text-blue-600">Studio Pro</span>{% endblock %}
+{% block content %}
 
     <div id="error-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="error-title" aria-describedby="error-message">
         <div class="flex items-center justify-center min-h-screen px-4">
@@ -247,7 +239,7 @@
                 <div class="flex justify-center items-center gap-2 flex-wrap">
                     <a id="download-btn" href="#" download="pro-meme-result-static.png" class="hidden items-center bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica PNG</a>
 
-                    <button id="add-gallery-btn" class="hidden items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
+                    <button id="add-gallery-btn" class="hidden fixed bottom-4 right-4 z-20 items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
                     
                     <button id="download-anim-btn" class="hidden items-center bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica Animato</button>
                     <select id="anim-fmt" class="hidden bg-gray-700 text-sm text-white rounded-full px-3 py-2 shadow-lg cursor-pointer">
@@ -269,6 +261,8 @@
         </div>
     </div>
     
-    <script type="module" src="{{ url_for('static', filename='js/main.js') }}" defer></script>
-</body>
-</html>
+<div id="toast" class="fixed bottom-20 right-4 bg-gray-800 text-white px-3 py-2 rounded shadow hidden"></div>
+{% endblock %}
+{% block scripts %}
+<script type='module' src='{{ url_for('static', filename='js/main.js') }}' defer></script>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="it" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}FaceSwap{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body class="antialiased bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-300">
+<div class="flex min-h-screen">
+    <aside id="sidebar" class="hidden md:flex flex-col w-56 bg-gray-800 text-gray-200 p-4 space-y-4 border-r border-gray-700 sticky top-0 h-screen overflow-y-auto">
+        <nav class="flex flex-col gap-3 text-sm">
+            <a href="{{ url_for('explore') }}" class="hover:text-white">Esplora</a>
+            <a href="{{ url_for('home') }}" class="hover:text-white">Crea</a>
+            <a href="{{ url_for('gallery_page') }}" class="hover:text-white">Galleria</a>
+            <button id="gallery-toggle" class="text-left hover:text-white">Galleria Local</button>
+        </nav>
+        <div id="gallery-container" class="gallery-grid hidden mt-4 overflow-y-auto"></div>
+    </aside>
+    <div class="flex flex-col flex-1 min-h-screen">
+        <header class="relative text-center py-6 bg-gray-200 dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700">
+            <button id="sidebar-toggle" class="md:hidden absolute left-4 top-4 p-2 rounded-md bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-400 dark:hover:bg-gray-600" aria-label="Apri menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
+            <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-gray-800 dark:text-white">{% block header_title %}FaceSwap{% endblock %}</h1>
+            <button id="theme-toggle" class="absolute right-4 top-4 p-2 rounded-md bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-400 dark:hover:bg-gray-600 transition-colors" aria-label="Attiva tema chiaro/scuro">
+                <svg id="theme-icon" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"></svg>
+            </button>
+        </header>
+        <main class="flex-1">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</div>
+<script type="module">
+import { initTheme } from '{{ url_for('static', filename='js/theme.js') }}';
+import { initSidebarToggle, loadGallery, setupGalleryInteraction } from '{{ url_for('static', filename='js/gallery.js') }}';
+
+const sidebar = document.getElementById('sidebar');
+const sidebarToggle = document.getElementById('sidebar-toggle');
+const galleryToggle = document.getElementById('gallery-toggle');
+const galleryContainer = document.getElementById('gallery-container');
+initTheme('theme-toggle','theme-icon');
+initSidebarToggle(sidebar, sidebarToggle, galleryToggle, galleryContainer);
+if (galleryContainer) loadGallery(galleryContainer).then(()=>setupGalleryInteraction(galleryContainer));
+</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable layout template with persistent sidebar
- convert pages to extend the new base layout
- fix image preview logic in workflow.js

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685009406688832995f0c1d411c1da3c