### PR TITLE
Fix image preview workflow

### DIFF
--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -28,7 +28,7 @@ export function assignDomElements() {
     'error-modal', 'progress-modal', 'progress-bar', 'progress-text', 'progress-title',
     'result-image-display', 'result-placeholder', 'meme-canvas',
     'download-btn', 'add-gallery-btn', 'download-anim-btn', 'anim-fmt', 'share-btn', 'reset-all-btn',
-    'step-1-subject', 'subject-img-input', 'subject-img-preview', 'subject-upload-prompt',
+    'step-1-subject', 'fileInput', 'imagePreview', 'subject-upload-prompt',
     'prepare-subject-btn', 'skip-to-swap-btn',
     'step-2-scene', 'bg-prompt-input', 'auto-enhance-prompt-toggle', 'generate-scene-btn', 'goto-step-3-btn',
     'step-3-upscale', 'enable-hires-upscale-toggle', 'tile-denoising-slider', 'tile-denoising-value',

--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -19,7 +19,7 @@ export function displayImage(src, imageElement) {
       dom.downloadBtn.classList.remove('hidden');
       dom.addGalleryBtn.classList.remove('hidden');
       dom.shareBtn.classList.remove('hidden');
-    } else if (imageElement.id === 'subject-img-preview') {
+    } else if (imageElement.id === 'imagePreview') {
       dom.subjectUploadPrompt.style.display = 'none';
     } else if (imageElement.id === 'source-img-preview') {
       dom.sourceUploadPrompt.style.opacity = '0';
@@ -81,7 +81,7 @@ export function goToStep(stepNumber) {
 export function handleSubjectFile(file) {
   if (!file?.type.startsWith('image/')) return;
   state.subjectFile = file;
-  displayImage(file, dom.subjectImgPreview);
+  displayImage(file, dom.imagePreview);
   dom.prepareSubjectBtn.disabled = false;
   dom.skipToSwapBtn.disabled = false;
 }
@@ -274,7 +274,7 @@ export function setupEventListeners() {
     }
   });
   dom.resetAllBtn.addEventListener('click', resetWorkflow);
-  dom.subjectImgInput.addEventListener('change', e => handleSubjectFile(e.target.files[0]));
+  dom.fileInput.addEventListener('change', e => handleSubjectFile(e.target.files[0]));
   dom.prepareSubjectBtn.addEventListener('click', handlePrepareSubject);
   dom.skipToSwapBtn.addEventListener('click', handleSkipToSwap);
   dom.generateSceneBtn.addEventListener('click', handleCreateScene);
@@ -437,13 +437,13 @@ export function resetWorkflow() {
   state.currentStep = 1;
   state.subjectFile = state.processedSubjectBlob = state.sceneImageBlob = state.upscaledImageBlob = state.finalImageWithSwap = null;
   state.activeFilter = 'none';
-  dom.subjectImgPreview.src = '';
-  dom.subjectImgPreview.classList.add('hidden');
+  dom.imagePreview.src = '';
+  dom.imagePreview.classList.add('hidden');
   dom.subjectUploadPrompt.style.display = 'block';
   dom.sourceImgPreview.src = '';
   dom.sourceImgPreview.classList.add('hidden');
   dom.sourceUploadPrompt.style.opacity = '1';
-  ['subjectImgInput', 'sourceImgInput', 'bgPromptInput', 'captionTextInput'].forEach(id => dom[id] && (dom[id].value = ''));
+  ['fileInput', 'sourceImgInput', 'bgPromptInput', 'captionTextInput'].forEach(id => dom[id] && (dom[id].value = ''));
   dom.tileDenoisingSlider.value = '0.4';
   dom.tileDenoisingValue.textContent = '0.40';
   dom.memeCanvas.getContext('2d').clearRect(0, 0, dom.memeCanvas.width, dom.memeCanvas.height);
@@ -467,8 +467,8 @@ export function resetWorkflow() {
   dom.toggleFaceBoxes.checked = true;
   if (dom.sourceFaceBoxesContainer) dom.sourceFaceBoxesContainer.innerHTML = '';
   if (dom.targetFaceBoxesContainer) dom.targetFaceBoxesContainer.innerHTML = '';
-  dom.subjectImgPreview.src = '';
-  dom.subjectImgPreview.classList.add('hidden');
+  dom.imagePreview.src = '';
+  dom.imagePreview.classList.add('hidden');
   dom.targetFaceBoxesContainer.style.display = 'block';
   dom.sourceFaceBoxesContainer.style.display = 'block';
   dom.filterButtonsContainer.querySelector('.active')?.classList.remove('active');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,14 +35,14 @@
     <div id="controls-column" class="flex flex-col gap-6">
         <div id="step-1-subject" class="wizard-step bg-gray-800 p-6 rounded-xl shadow-lg">
             <h2 class="text-2xl font-bold text-blue-400 mb-4 border-b border-gray-700 pb-2">Step 1: Carica Immagine</h2>
-            <label for="subject-img-input" class="upload-box flex flex-col items-center justify-center p-4 rounded-lg min-h-[250px]">
-                <img id="subject-img-preview" src="" alt="Anteprima Soggetto" class="hidden rounded-lg" />
+            <label for="fileInput" class="upload-box flex flex-col items-center justify-center p-4 rounded-lg min-h-[250px]">
+                <img id="imagePreview" src="" alt="Anteprima Soggetto" class="hidden rounded-lg" />
                 <div id="subject-upload-prompt" class="text-center">
                     <svg class="w-12 h-12 mx-auto text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                     <p class="mt-2 text-sm font-medium text-gray-400">Clicca o trascina l'immagine di partenza</p>
                 </div>
             </label>
-            <input type="file" id="subject-img-input" accept="image/*" class="hidden">
+            <input type="file" id="fileInput" accept="image/*" class="hidden">
             <p class="text-center text-xs text-gray-400 my-3">Dopo aver caricato un'immagine, scegli cosa fare:</p>
             <button id="prepare-subject-btn" class="btn btn-primary w-full text-white font-bold py-3 px-4 rounded-lg disabled:opacity-50" disabled>1. Rimuovi Sfondo e Inizia Workflow</button>
             <button id="skip-to-swap-btn" class="btn bg-teal-600 hover:bg-teal-700 w-full mt-2 text-white font-bold py-3 px-4 rounded-lg disabled:opacity-50" disabled>2. Usa Immagine Diretta (Vai a Step 4)</button>


### PR DESCRIPTION
## Summary
- rename subject file input and preview elements for easier JS access
- handle `change` event on new file input to display preview
- reset preview correctly in the workflow
- update ID list for DOM mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503d4b56588329ab017dffd36e65be