### PR TITLE
Fix meme gallery and facebox layout

### DIFF
--- a/app/static/js/facebox.js
+++ b/app/static/js/facebox.js
@@ -5,7 +5,7 @@ import { showError } from './workflow.js';
 export function drawFaceBoxes(container, image, faces, type) {
   if (!container || !image || !image.complete || image.naturalWidth === 0) return;
   container.innerHTML = '';
-  const rect = image.getBoundingClientRect();
+  const rect = container.getBoundingClientRect();
   if (!rect.width) return;
   const scaleX = rect.width / image.naturalWidth;
   const scaleY = rect.height / image.naturalHeight;

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -26,6 +26,9 @@ function renderGallery(container, items) {
     const title = document.createElement('p');
     title.className = 'text-xs text-white truncate';
     title.textContent = m.title || '';
+    const time = document.createElement('p');
+    time.className = 'text-[10px] text-gray-300';
+    time.textContent = m.ts ? new Date(m.ts).toLocaleString() : '';
     const actions = document.createElement('div');
     actions.className = 'flex justify-end gap-1';
     actions.innerHTML = `
@@ -39,6 +42,7 @@ function renderGallery(container, items) {
         <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M6 18L18 6M6 6l12 12"/></svg>
       </button>`;
     overlay.appendChild(title);
+    overlay.appendChild(time);
     overlay.appendChild(actions);
     card.appendChild(img);
     card.appendChild(overlay);
@@ -84,14 +88,6 @@ export function initSidebarToggle(sidebar, toggleBtn, galleryToggle, galleryCont
   if (galleryToggle && galleryContainer) {
     galleryToggle.addEventListener('click', () => galleryContainer.classList.toggle('hidden'));
   }
-}
-
-export function addToGallery(title, dataUrl) {
-  const list = JSON.parse(localStorage.getItem('userGallery') || '[]');
-  list.push({ title, url: dataUrl, local: true });
-  localStorage.setItem('userGallery', JSON.stringify(list));
-  const container = document.getElementById('gallery-container');
-  if (container) renderGallery(container, list);
 }
 
 function showToast(msg) {
@@ -143,7 +139,8 @@ export async function loadExplore(container) {
       const overlay=document.createElement('div');
       overlay.className='gallery-item-overlay';
       const p=document.createElement('p'); p.className='text-xs text-white truncate'; p.textContent=m.title||'';
-      overlay.appendChild(p); card.appendChild(img); card.appendChild(overlay); container.appendChild(card);
+      const time=document.createElement('p'); time.className='text-[10px] text-gray-300'; time.textContent=m.ts?new Date(m.ts).toLocaleString():'';
+      overlay.appendChild(p); overlay.appendChild(time); card.appendChild(img); card.appendChild(overlay); container.appendChild(card);
     });
   }
   function fetchMore(){ if(index<filtered.length) renderSlice(); }
@@ -170,8 +167,6 @@ export async function addToGallery(title, dataUrl, caption='') {
   const list = JSON.parse(localStorage.getItem('userGallery') || '[]');
   list.push({ title, url: withText, caption, local: true, ts: Date.now() });
   localStorage.setItem('userGallery', JSON.stringify(list));
-  const container = document.getElementById('gallery-container');
-  if (container) renderGallery(container, list);
   window.dispatchEvent(new Event('gallery-updated'));
   showToast('Salvato nella galleria');
 }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -10,10 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
   assignDomElements();
   initFaceBoxObservers();
   initTheme(dom.themeToggle, dom.themeIcon);
-  initSidebarToggle(dom.sidebar, dom.sidebarToggle, dom.galleryToggle, dom.galleryContainer);
+  initSidebarToggle(dom.sidebar, dom.sidebarToggle);
   setupEventListeners();
   loadStickers();
-  loadGallery(dom.galleryContainer).then(() => setupGalleryInteraction(dom.galleryContainer));
+  if (dom.galleryContainer) {
+    loadGallery(dom.galleryContainer).then(() => setupGalleryInteraction(dom.galleryContainer));
+  }
   resetWorkflow();
   animationLoop();
   window.closeModal = closeModal;

--- a/app/static/js/memeEditor.js
+++ b/app/static/js/memeEditor.js
@@ -1,6 +1,7 @@
 import { state, dom } from './state.js';
 import * as api from './api.js';
 import { showError, startProgressBar, finishProgressBar } from './workflow.js';
+import { refreshFaceBoxes } from './facebox.js';
 
 export function updateMemePreview() {
   const imageToDrawOn = dom.resultImageDisplay;
@@ -18,6 +19,7 @@ export function updateMemePreview() {
   dom.memeCanvas.classList.toggle('hidden', !shouldShowCanvas);
   if (text) drawMemeText(ctx);
   state.stickerStack.forEach(sticker => drawSticker(ctx, sticker));
+  if (!dom.resultImageDisplay.classList.contains('hidden')) refreshFaceBoxes();
 }
 
 function drawMemeText(ctx) {

--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -47,7 +47,7 @@ export function assignDomElements() {
     'dynamic-prompts-container',
     'generate-all-btn',
     'theme-toggle', 'theme-icon',
-    'sidebar', 'sidebar-toggle', 'gallery-toggle', 'gallery-container',
+    'sidebar', 'sidebar-toggle',
     'gallery-modal', 'gallery-modal-img'
   ];
   ids.forEach(id => {

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -16,9 +16,7 @@
             <a href="{{ url_for('explore') }}" class="hover:text-white">Esplora</a>
             <a href="{{ url_for('home') }}" class="hover:text-white">Crea</a>
             <a href="{{ url_for('gallery_page') }}" class="hover:text-white">Galleria</a>
-            <button id="gallery-toggle" class="text-left hover:text-white">Galleria Local</button>
         </nav>
-        <div id="gallery-container" class="gallery-grid hidden mt-4 overflow-y-auto"></div>
     </aside>
     <div class="flex flex-col flex-1 min-h-screen">
         <header class="relative text-center py-6 bg-gray-200 dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700">
@@ -42,11 +40,8 @@ import { initSidebarToggle, loadGallery, setupGalleryInteraction } from '{{ url_
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   const sidebarToggle = document.getElementById('sidebar-toggle');
-  const galleryToggle = document.getElementById('gallery-toggle');
-  const galleryContainer = document.getElementById('gallery-container');
   initTheme('theme-toggle','theme-icon');
-  initSidebarToggle(sidebar, sidebarToggle, galleryToggle, galleryContainer);
-  if (galleryContainer) loadGallery(galleryContainer).then(()=>setupGalleryInteraction(galleryContainer));
+  initSidebarToggle(sidebar, sidebarToggle);
 });
 </script>
 {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- anchor face detection boxes to the preview container
- improve gallery rendering and remove sidebar gallery
- allow optional gallery initialization
- refresh bounding boxes when editing memes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041a9229883299b46afd05dcf4308