### PR TITLE
Remove unused element references

### DIFF
--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -42,7 +42,6 @@ export function assignDomElements() {
     'meme-section', 'caption-text-input', 'caption-btn', 'tone-buttons-container',
     'font-family-select', 'font-size-slider', 'font-size-value',
     'font-color-input', 'stroke-color-input', 'position-buttons', 'text-bg-buttons',
-    'inpainting-prompt-input', 'generate-hair-btn',
     'analyze-parts-btn',
     'dynamic-prompts-container',
     'generate-all-btn',


### PR DESCRIPTION
## Summary
- drop `inpainting-prompt-input` and `generate-hair-btn` from the DOM assignment list

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850450546548329a6b529484f685287