### PR TITLE
UI fixes for face box overlays

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -31,7 +31,7 @@
     font-weight: 600;
     border-radius: 0.5rem;
     padding: 0.5rem 1rem;
-    transition: background-color 0.2s;
+    transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
 }
 .btn:focus-visible {
     outline: 2px solid var(--accent);
@@ -50,6 +50,10 @@
 }
 .btn-secondary:hover {
     background-color: var(--secondary-hover);
+}
+.btn:hover {
+    transform: scale(1.02);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.25);
 }
 
 #sidebar {

--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -76,7 +76,9 @@ export function goToStep(stepNumber) {
   state.currentStep = stepNumber;
   document.querySelectorAll('.wizard-step').forEach(step => step.classList.add('hidden'));
   const stepId = `step-${stepNumber}-${['subject', 'scene', 'upscale', 'finalize'][stepNumber - 1]}`;
-  document.getElementById(stepId)?.classList.remove('hidden');
+  const stepEl = document.getElementById(stepId);
+  if (stepEl) stepEl.classList.remove('hidden');
+  setTimeout(refreshFaceBoxes, 50);
 }
 export function handleSubjectFile(file) {
   if (!file?.type.startsWith('image/')) return;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -195,7 +195,6 @@
         </div>
         <div class="flex justify-center items-center gap-2 flex-wrap">
             <a id="download-btn" href="#" download="pro-meme-result-static.png" class="hidden items-center bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica PNG</a>
-            <button id="add-gallery-btn" class="hidden fixed bottom-4 right-4 z-20 items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
             <button id="download-anim-btn" class="hidden items-center bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Scarica Animato</button>
             <select id="anim-fmt" class="hidden bg-gray-700 text-sm text-white rounded-full px-3 py-2 shadow-lg cursor-pointer">
                 <option value="mp4">MP4</option>
@@ -206,6 +205,9 @@
                 Condividi
             </button>
             <button id="reset-all-btn" class="btn bg-red-800 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Reset Totale</button>
+        </div>
+        <div class="flex justify-center mt-4">
+            <button id="add-gallery-btn" class="hidden items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
         </div>
     </div>
 </main>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -169,3 +169,10 @@ def test_home_page(client):
     res = client.get('/')
     assert res.status_code == 200
     assert b"AI Face Swap Studio Pro" in res.data
+
+def test_frontend_elements_present(client):
+    res = client.get('/')
+    html = res.data.decode()
+    assert 'id="source-face-boxes-container"' in html
+    assert 'id="target-face-boxes-container"' in html
+    assert 'id="add-gallery-btn"' in html


### PR DESCRIPTION
## Summary
- ensure `goToStep` refreshes bounding boxes
- center gallery button under preview actions
- add hover effects to buttons
- test for face overlay containers and gallery button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504805bc9c83299b2b8e244b3aacd6