### PR TITLE
Implement stable gallery IDs

### DIFF
--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -4,7 +4,7 @@ import * as api from './api.js';
 import { state, dom } from './state.js';
 import { updateMemePreview, handleDownloadAnimation } from './memeEditor.js';
 import { getStickerAtPosition } from './stickers.js';
-import { addToGallery } from './gallery.js';
+import { addToGallery, migrateGallery } from './gallery.js';
 import { drawFaceBoxes, updateSelectionHighlights, refreshFaceBoxes, detectAndDrawFaces } from "./facebox.js";
 
 export function displayImage(src, imageElement, onLoadCallback = null) {
@@ -423,7 +423,7 @@ export function setupEventListeners() {
   dom.addGalleryBtn.addEventListener('click', () => {
     updateMemePreview();
     const src = dom.memeCanvas.toDataURL('image/png');
-    const list = JSON.parse(localStorage.getItem('userGallery') || '[]');
+    const list = migrateGallery();
     const title = `Meme #${list.length + 1}`;
     addToGallery(title, src, dom.captionTextInput.value);
   });


### PR DESCRIPTION
## Summary
- generate unique IDs for locally saved gallery items
- migrate old gallery entries on load
- handle deletions by ID
- expose migrateGallery for workflow
- use migrateGallery when saving new items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508fecc2f483299b5cf08b948f0b66