### PR TITLE
Enhance gallery sharing and explore filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ app/temp/
 temp/masks/
 
 
+.venv/

--- a/app/server.py
+++ b/app/server.py
@@ -341,15 +341,37 @@ def create_app():
         gallery_dir = os.path.join(app.static_folder, "gallery")
         if not os.path.isdir(gallery_dir):
             return jsonify([])
+
+        def collect_items(path):
+            meta = {}
+            meta_path = os.path.join(path, "meta.json")
+            if os.path.isfile(meta_path):
+                try:
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        meta = json.load(f) or {}
+                except Exception:
+                    meta = {}
+            for fname in sorted(os.listdir(path)):
+                if not fname.lower().endswith((".png", "jpg", "jpeg", "webp", "gif")):
+                    continue
+                info = meta.get(fname, {})
+                if not info.get("shared"):
+                    continue
+                rel = os.path.relpath(os.path.join(path, fname), app.static_folder)
+                yield {
+                    "title": info.get("title", os.path.splitext(fname)[0]),
+                    "url": url_for("static", filename=rel.replace(os.sep, "/")),
+                    "caption": info.get("caption", ""),
+                    "tags": info.get("tags", []),
+                    "ts": info.get("ts"),
+                    "shared": True,
+                }
+
         items = []
-        for fname in sorted(os.listdir(gallery_dir)):
-            if fname.lower().endswith((".png", ".jpg", ".jpeg", ".webp", ".gif")):
-                items.append(
-                    {
-                        "title": os.path.splitext(fname)[0],
-                        "url": url_for("static", filename=f"gallery/{fname}"),
-                    }
-                )
+        for root, dirs, files in os.walk(gallery_dir):
+            items.extend(list(collect_items(root)))
+
+        items.sort(key=lambda x: x.get("ts") or 0, reverse=True)
         return jsonify(items)
 
     @app.route("/api/memes")

--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -423,9 +423,15 @@ export function setupEventListeners() {
   dom.addGalleryBtn.addEventListener('click', () => {
     updateMemePreview();
     const src = dom.memeCanvas.toDataURL('image/png');
-    const list = JSON.parse(localStorage.getItem('userGallery') || '[]');
-    const title = `Meme #${list.length + 1}`;
-    addToGallery(title, src, dom.captionTextInput.value);
+    const data = JSON.parse(localStorage.getItem('galleryData') || '{}');
+    const user = localStorage.getItem('username') || 'user';
+    let count = 0;
+    const u = data[user] || {};
+    Object.values(u).forEach(tags => {
+      Object.values(tags).forEach(arr => { count += arr.length; });
+    });
+    const title = `Meme #${count + 1}`;
+    addToGallery(title, src, dom.captionTextInput.value, [], false);
   });
   dom.shareBtn.addEventListener('click', handleShare);
   dom.downloadAnimBtn.addEventListener('click', handleDownloadAnimation);


### PR DESCRIPTION
## Summary
- store gallery data hierarchically by user/date/tag with shared flag
- toggle shared status from gallery UI
- filter Explore view to only show shared items
- update API to read `meta.json` for shared images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508fee28a4832994a59134a284a1fd