### PR TITLE
Add basic authentication system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Ambiente Python
 /venv/
+.venv/
 __pycache__/
 
 # File sensibili e di sistema

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,52 @@
+from functools import wraps
+from flask import Blueprint, render_template, request, redirect, url_for, session
+
+from .user_model import create_user, verify_user
+
+
+auth_bp = Blueprint('auth', __name__)
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if 'user_id' not in session:
+            return redirect(url_for('auth.login'))
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username', '').strip()
+        password = request.form.get('password', '')
+        if verify_user(username, password):
+            session['user_id'] = username
+            return redirect(url_for('home'))
+        error = 'Credenziali non valide'
+    return render_template('login.html', error=error)
+
+
+@auth_bp.route('/logout')
+def logout():
+    session.pop('user_id', None)
+    return redirect(url_for('auth.login'))
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username', '').strip()
+        password = request.form.get('password', '')
+        if not username or not password:
+            error = 'Inserisci username e password'
+        elif create_user(username, password):
+            session['user_id'] = username
+            return redirect(url_for('home'))
+        else:
+            error = 'Utente già esistente'
+    return render_template('register.html', error=error)

--- a/app/server.py
+++ b/app/server.py
@@ -38,6 +38,7 @@ from flask import (
 from werkzeug.utils import safe_join
 from flask_cors import CORS
 from app.meme_studio import meme_bp, GEMINI_MODEL_NAME
+from app.auth import auth_bp, login_required
 from dotenv import load_dotenv
 
 try:
@@ -297,8 +298,10 @@ def create_app():
     app = Flask(__name__)
     load_dotenv()
     app.config["GEMINI_API_KEY"] = os.getenv("GEMINI_API_KEY")
+    app.secret_key = os.getenv("SECRET_KEY", "dev-key")
     CORS(app, resources={r"/*": {"origins": "*"}})
     app.register_blueprint(meme_bp)
+    app.register_blueprint(auth_bp)
 
     @app.route("/")
     def home():
@@ -309,6 +312,7 @@ def create_app():
         return render_template("esplora.html")
 
     @app.route("/gallery")
+    @login_required
     def gallery_page():
         return render_template("galleria.html")
 
@@ -357,6 +361,7 @@ def create_app():
         return get_approved_memes()
 
     @app.route("/api/meme", methods=["POST"])
+    @login_required
     def api_add_meme():
         if "image" not in request.files:
             return jsonify({"error": "Immagine mancante"}), 400

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -207,7 +207,11 @@
             <button id="reset-all-btn" class="btn bg-red-800 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Reset Totale</button>
         </div>
         <div class="flex justify-center mt-4">
+            {% if session.get('user_id') %}
             <button id="add-gallery-btn" class="hidden items-center bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full text-sm shadow-lg">Aggiungi a Galleria</button>
+            {% else %}
+            <p class="text-sm text-gray-400">Accedi per salvare nella galleria</p>
+            {% endif %}
         </div>
     </div>
 </main>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -15,7 +15,12 @@
         <nav class="flex flex-col gap-3 text-sm">
             <a href="{{ url_for('explore') }}" class="hover:text-white">Esplora</a>
             <a href="{{ url_for('home') }}" class="hover:text-white">Crea</a>
+            {% if session.get('user_id') %}
             <a href="{{ url_for('gallery_page') }}" class="hover:text-white">Galleria</a>
+            <a href="{{ url_for('auth.logout') }}" class="hover:text-white">Logout</a>
+            {% else %}
+            <a href="{{ url_for('auth.login') }}" class="hover:text-white">Login</a>
+            {% endif %}
         </nav>
     </aside>
     <div class="flex flex-col flex-1 min-h-screen">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block title %}Login{% endblock %}
+{% block header_title %}Login{% endblock %}
+{% block content %}
+<div class="max-w-sm mx-auto p-4">
+  <form method="post" class="space-y-4">
+    <input name="username" type="text" required class="w-full p-2 rounded-md bg-gray-800 border border-gray-700" placeholder="Username">
+    <input name="password" type="password" required class="w-full p-2 rounded-md bg-gray-800 border border-gray-700" placeholder="Password">
+    {% if error %}<p class="text-red-500 text-sm">{{ error }}</p>{% endif %}
+    <button type="submit" class="btn btn-primary w-full">Accedi</button>
+  </form>
+  <p class="mt-2 text-center text-sm"><a href="{{ url_for('auth.register') }}" class="text-blue-500">Registrati</a></p>
+</div>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block title %}Registrazione{% endblock %}
+{% block header_title %}Registrazione{% endblock %}
+{% block content %}
+<div class="max-w-sm mx-auto p-4">
+  <form method="post" class="space-y-4">
+    <input name="username" type="text" required class="w-full p-2 rounded-md bg-gray-800 border border-gray-700" placeholder="Username">
+    <input name="password" type="password" required class="w-full p-2 rounded-md bg-gray-800 border border-gray-700" placeholder="Password">
+    {% if error %}<p class="text-red-500 text-sm">{{ error }}</p>{% endif %}
+    <button type="submit" class="btn btn-primary w-full">Registrati</button>
+  </form>
+  <p class="mt-2 text-center text-sm"><a href="{{ url_for('auth.login') }}" class="text-blue-500">Accedi</a></p>
+</div>
+{% endblock %}

--- a/app/user_model.py
+++ b/app/user_model.py
@@ -1,0 +1,35 @@
+import json
+import os
+from werkzeug.security import generate_password_hash, check_password_hash
+
+_USER_FILE = os.path.join(os.path.dirname(__file__), 'users.json')
+
+
+def _load_users():
+    if os.path.exists(_USER_FILE):
+        with open(_USER_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+def _save_users(data):
+    with open(_USER_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+
+
+_users = _load_users()
+
+
+def create_user(username: str, password: str) -> bool:
+    if username in _users:
+        return False
+    _users[username] = generate_password_hash(password)
+    _save_users(_users)
+    return True
+
+
+def verify_user(username: str, password: str) -> bool:
+    hash_ = _users.get(username)
+    if not hash_:
+        return False
+    return check_password_hash(hash_, password)


### PR DESCRIPTION
## Summary
- handle user data with hashed passwords
- create auth blueprint with login, logout, register routes
- store user id in session, add login-required decorator
- update layout and index templates to show login-related UI
- secure gallery page and meme upload endpoint
- ignore local `.venv` folder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68508ff7066c832981f424496e4ce8bb