### PR TITLE
Add CSRF protection with Flask-WTF

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,5 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField
+
+class SearchForm(FlaskForm):
+    query = StringField('query')

--- a/app/server.py
+++ b/app/server.py
@@ -37,7 +37,9 @@ from flask import (
 )
 from werkzeug.utils import safe_join
 from flask_cors import CORS
+from flask_wtf import CSRFProtect
 from app.meme_studio import meme_bp, GEMINI_MODEL_NAME
+from .forms import SearchForm
 from dotenv import load_dotenv
 
 try:
@@ -296,7 +298,9 @@ def make_mask(pil_img, parts_to_mask, conf_threshold=0.20):
 def create_app():
     app = Flask(__name__)
     load_dotenv()
+    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", os.urandom(24).hex())
     app.config["GEMINI_API_KEY"] = os.getenv("GEMINI_API_KEY")
+    csrf = CSRFProtect(app)
     CORS(app, resources={r"/*": {"origins": "*"}})
     app.register_blueprint(meme_bp)
 
@@ -306,11 +310,13 @@ def create_app():
 
     @app.route("/explore")
     def explore():
-        return render_template("esplora.html")
+        form = SearchForm()
+        return render_template("esplora.html", form=form)
 
     @app.route("/gallery")
     def gallery_page():
-        return render_template("galleria.html")
+        form = SearchForm()
+        return render_template("galleria.html", form=form)
 
     @app.route("/api/stickers")
     def get_stickers_api():

--- a/app/server_mod.py
+++ b/app/server_mod.py
@@ -12,6 +12,7 @@ if pil_image_mod and not hasattr(pil_image_mod, 'Image'):
 from .server import create_app
 
 app = create_app()
+app.config['WTF_CSRF_ENABLED'] = False
 
 # Minimal routes required by tests
 @app.route('/swap_face', methods=['POST'])

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -1,6 +1,15 @@
 // API.JS - Modulo per la comunicazione con il server
 // BASE_URL dinamica: funziona da qualsiasi host
 const BASE_URL = window.location.origin;
+const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+
+function csrfFetch(url, options = {}) {
+    options.headers = options.headers || {};
+    if (csrfToken) {
+        options.headers['X-CSRFToken'] = csrfToken;
+    }
+    return fetch(url, options);
+}
 
 async function handleResponse(response) {
     if (!response.ok) {
@@ -32,7 +41,7 @@ async function blobToBase64(blob) {
 }
 
 export async function getStickers() {
-    const response = await fetch(`${BASE_URL}/api/stickers`);
+    const response = await csrfFetch(`${BASE_URL}/api/stickers`);
     await handleResponse(response);
     return response.json();
 }
@@ -40,7 +49,7 @@ export async function getStickers() {
 export async function prepareSubject(subjectFile) {
     const formData = new FormData();
     formData.append('subject_image', subjectFile);
-    const response = await fetch(`${BASE_URL}/prepare_subject`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/prepare_subject`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }
@@ -49,7 +58,7 @@ export async function createScene(processedSubjectBlob, finalPrompt) {
     const formData = new FormData();
     formData.append('subject_data', processedSubjectBlob);
     formData.append('prompt', finalPrompt);
-    const response = await fetch(`${BASE_URL}/create_scene`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/create_scene`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }
@@ -59,7 +68,7 @@ export async function upscaleAndDetail(sceneImageBlob, enableHires, denoising) {
     formData.append('scene_image', sceneImageBlob);
     formData.append('enable_hires', enableHires);
     formData.append('tile_denoising_strength', denoising);
-    const response = await fetch(`${BASE_URL}/detail_and_upscale`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/detail_and_upscale`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }
@@ -67,7 +76,7 @@ export async function upscaleAndDetail(sceneImageBlob, enableHires, denoising) {
 export async function detectFaces(imageBlob) {
     const formData = new FormData();
     formData.append('image', imageBlob);
-    const response = await fetch(`${BASE_URL}/detect_faces`, { method: 'POST', body: formData });
+    const response = await csrfFetch(`${BASE_URL}/detect_faces`, { method: 'POST', body: formData });
     await handleResponse(response);
     return response.json();
 }
@@ -78,7 +87,7 @@ export async function performSwap(targetImageBlob, sourceImageFile, sourceIndex,
     formData.append('source_face_image', sourceImageFile);
     formData.append('source_face_index', sourceIndex);
     formData.append('target_face_index', targetIndex);
-    const response = await fetch(`${BASE_URL}/final_swap`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/final_swap`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }
@@ -86,7 +95,7 @@ export async function performSwap(targetImageBlob, sourceImageFile, sourceIndex,
 // Modificata per inviare l'immagine in base64
 export async function enhancePrompt(imageBlob, userPrompt) {
     const base64ImageData = await blobToBase64(imageBlob);
-    const response = await fetch(`${BASE_URL}/enhance_prompt`, {
+    const response = await csrfFetch(`${BASE_URL}/enhance_prompt`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ image_data: base64ImageData, prompt_text: userPrompt })
@@ -98,7 +107,7 @@ export async function enhancePrompt(imageBlob, userPrompt) {
 // Modificata per inviare l'immagine in base64
 export async function enhancePartPrompt(partName, userPrompt, imageBlob) {
     const base64ImageData = await blobToBase64(imageBlob);
-    const response = await fetch(`${BASE_URL}/enhance_part_prompt`, {
+    const response = await csrfFetch(`${BASE_URL}/enhance_part_prompt`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ part_name: partName, prompt_text: userPrompt, image_data: base64ImageData })
@@ -109,7 +118,7 @@ export async function enhancePartPrompt(partName, userPrompt, imageBlob) {
 
 export async function generateCaption(imageBlob, tone) {
     const base64ImageData = await blobToBase64(imageBlob); // Usa la nuova helper
-    const response = await fetch(`${BASE_URL}/meme/generate_caption`, {
+    const response = await csrfFetch(`${BASE_URL}/meme/generate_caption`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ image_data: base64ImageData, tone: tone })
@@ -119,7 +128,7 @@ export async function generateCaption(imageBlob, tone) {
 }
 
 export async function saveResultVideo(videoBlob, format) {
-    const response = await fetch(`${BASE_URL}/save_result_video?fmt=${format}`, {
+    const response = await csrfFetch(`${BASE_URL}/save_result_video?fmt=${format}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/octet-stream' 
@@ -138,7 +147,7 @@ export async function generateWithMask(imageBlob, partName, prompt) { // Aggiunt
     formData.append('prompt', prompt);
     // Cambiato l'endpoint da generate_with_mask a generate_all_parts
     // per coerenza con il nuovo inpainting basato sul crop
-    const response = await fetch(`${BASE_URL}/generate_all_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/generate_all_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }
@@ -146,7 +155,7 @@ export async function generateWithMask(imageBlob, partName, prompt) { // Aggiunt
 export async function analyzeParts(imageBlob) {
     const formData = new FormData();
     formData.append('image', imageBlob);
-    const response = await fetch(`${BASE_URL}/analyze_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/analyze_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.json();
 }
@@ -158,7 +167,7 @@ export async function generateAllParts(imageBlob, prompts) {
     
     // NOTA: il problema precedente era che questo chiamava /generate_with_mask.
     // Assicurati che qui chiami generate_all_parts
-    const response = await fetch(`${BASE_URL}/generate_all_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
+    const response = await csrfFetch(`${BASE_URL}/generate_all_parts`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();
 }

--- a/app/templates/esplora.html
+++ b/app/templates/esplora.html
@@ -3,7 +3,10 @@
 {% block header_title %}Esplora{% endblock %}
 {% block content %}
 <div class="p-4">
-  <input type="search" id="explore-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca immagini">
+  <form id="explore-search-form" method="GET">
+    {{ form.csrf_token }}
+    <input type="search" name="query" id="explore-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca immagini">
+  </form>
   <div id="explore-grid" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
   <div id="sentinel" class="h-10"></div>
 </div>

--- a/app/templates/galleria.html
+++ b/app/templates/galleria.html
@@ -3,7 +3,10 @@
 {% block header_title %}Galleria{% endblock %}
 {% block content %}
 <div class="p-4">
-  <input type="search" id="gallery-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca nella galleria">
+  <form id="gallery-search-form" method="GET">
+    {{ form.csrf_token }}
+    <input type="search" name="query" id="gallery-search" placeholder="Cerca" class="w-full mb-4 p-2 rounded-md bg-gray-800 border border-gray-700" aria-label="Cerca nella galleria">
+  </form>
   <div id="user-gallery" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
 </div>
 <div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="gallery-modal-img">

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}FaceSwap{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,5 +1,6 @@
 Flask==3.1.1
 flask-cors==6.0.0
+Flask-WTF==1.2.1
 python-dotenv==1.0.0
 requests==2.32.4
 tqdm==4.67.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 # -------------------------------------------------
 Flask==3.1.1
 flask-cors==6.0.0
+Flask-WTF==1.2.1
 python-dotenv==1.1.0         #  <-- mancava, ora c’è
 requests==2.32.4
 tqdm==4.67.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ filelock==3.13.1
 filterpy==1.4.5
 Flask==3.1.1
 flask-cors==6.0.0
+Flask-WTF==1.2.1
 flatbuffers==25.2.10
 fonttools==4.58.2
 fsspec==2024.6.1


### PR DESCRIPTION
## Summary
- add Flask-WTF to dependencies
- configure CSRF protection and secret key
- supply a simple `SearchForm`
- inject csrf token in base template and wrap search forms
- include CSRF token in JS API requests
- disable CSRF in `server_mod` for tests

## Testing
- `pip install -q Flask-WTF==1.2.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508ff963b48329877a4843b089fb45