### PR TITLE
Update debug mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Create `.env` in the project root:
 
 ```bash
 GEMINI_API_KEY="YOUR_GOOGLE_GEMINI_KEY"
+# Enable verbose logging (development only). Leave unset or 0 in production
+DEBUG_MODE=1
 ```
 
 ### Run Locally/Production

--- a/app/server.py
+++ b/app/server.py
@@ -60,7 +60,7 @@ except ImportError:
     ffmpeg_path = None
 
 # === CONFIGURAZIONE GLOBALE ===
-DEBUG_MODE = True
+DEBUG_MODE = os.getenv("DEBUG_MODE", "0") == "1"
 CFG_MODEL_NAME = "sdxl-yamers-realistic5-v5Rundiffusion"
 CFG_DETAIL_STEPS = 18
 MAX_IMAGE_DIMENSION = 1280


### PR DESCRIPTION
## Summary
- make DEBUG_MODE read from environment
- document enabling DEBUG_MODE only for development

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ba1bc5808329910f5ec7e649875e