### PR TITLE
Add timeouts for Gemini requests

### DIFF
--- a/app/meme_studio.py
+++ b/app/meme_studio.py
@@ -50,7 +50,12 @@ def generate_caption_proxy():
 
         payload = {"contents": [{"parts": [{"text": system_prompt}, {"inlineData": {"mimeType": "image/jpeg", "data": base64_image}}]}]}
 
-        response = requests.post(google_api_url, headers={'Content-Type': 'application/json'}, json=payload)
+        response = requests.post(
+            google_api_url,
+            headers={'Content-Type': 'application/json'},
+            json=payload,
+            timeout=10,
+        )
         response.raise_for_status()
         result = response.json()
 
@@ -62,6 +67,8 @@ def generate_caption_proxy():
             error_info = result.get("promptFeedback", {})
             return jsonify({"error": f"Gemini non ha restituito una didascalia valida. Causa: {error_info}"}), 500
 
+    except requests.Timeout:
+        return jsonify({"error": "La richiesta a Gemini ha impiegato troppo tempo."}), 504
     except Exception as e:
         traceback.print_exc()
         return jsonify({"error": f"Errore durante la generazione della didascalia: {e}"}), 500
@@ -102,7 +109,10 @@ def generate_tags_proxy():
         }
 
         response = requests.post(
-            google_api_url, headers={"Content-Type": "application/json"}, json=payload
+            google_api_url,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=10,
         )
         response.raise_for_status()
         result = response.json()
@@ -115,6 +125,8 @@ def generate_tags_proxy():
             error_info = result.get("promptFeedback", {})
             return jsonify({"error": f"Gemini non ha restituito tag validi. Causa: {error_info}"}), 500
 
+    except requests.Timeout:
+        return jsonify({"error": "La richiesta a Gemini ha impiegato troppo tempo."}), 504
     except Exception as e:
         traceback.print_exc()
         return jsonify({"error": f"Errore durante la generazione dei tag: {e}"}), 500

--- a/app/server.py
+++ b/app/server.py
@@ -603,9 +603,12 @@ def create_app():
                 }]
             }
             url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL_NAME}:generateContent?key={api_key}"
-            resp = requests.post(url,
-                                 headers={"Content-Type": "application/json"},
-                                 json=payload)
+            resp = requests.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=10,
+            )
             resp.raise_for_status()
             result = resp.json()
             if result.get("candidates"):
@@ -613,6 +616,8 @@ def create_app():
                     "text"].strip('"')
                 return jsonify(enhanced_prompt=text)
             return jsonify(error="No prompt generated"), 500
+        except requests.Timeout:
+            return jsonify(error="La richiesta a Gemini ha impiegato troppo tempo."), 504
         except Exception as e:
             traceback.print_exc()
             return jsonify(error=f"Gemini error: {e}"), 500
@@ -649,9 +654,12 @@ def create_app():
                 }]
             }
             url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL_NAME}:generateContent?key={api_key}"
-            resp = requests.post(url,
-                                 headers={"Content-Type": "application/json"},
-                                 json=payload)
+            resp = requests.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=10,
+            )
             resp.raise_for_status()
             result = resp.json()
             if result.get("candidates"):
@@ -659,6 +667,8 @@ def create_app():
                     "text"].strip('"')
                 return jsonify(enhanced_prompt=text)
             return jsonify(error="No prompt generated"), 500
+        except requests.Timeout:
+            return jsonify(error="La richiesta a Gemini ha impiegato troppo tempo."), 504
         except Exception as e:
             traceback.print_exc()
             return jsonify(error=f"Gemini error: {e}"), 500


### PR DESCRIPTION
## Summary
- handle possible network delays when calling Gemini in **meme_studio.py** and **server.py**
- return a friendly message if the request exceeds ten seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ba20df2c8329b0ecefa668d6e50f