### PR TITLE
Add upload validation and file size limit

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -36,7 +36,7 @@ from flask import (
     url_for,
     session,
 )
-from werkzeug.utils import safe_join
+from werkzeug.utils import safe_join, secure_filename
 from flask_cors import CORS
 from flask_wtf import CSRFProtect
 from app.meme_studio import meme_bp, GEMINI_MODEL_NAME
@@ -64,6 +64,8 @@ DEBUG_MODE = True
 CFG_MODEL_NAME = "sdxl-yamers-realistic5-v5Rundiffusion"
 CFG_DETAIL_STEPS = 18
 MAX_IMAGE_DIMENSION = 1280
+MAX_UPLOAD_SIZE = 8 * 1024 * 1024  # 8MB limit
+ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 
 # === GESTIONE MODELLI ===
 (
@@ -81,6 +83,20 @@ def release_vram():
     print(" [VRAM] Rilascio della memoria cache della GPU...")
     gc.collect()
     torch.cuda.empty_cache()
+
+
+def validate_upload(file):
+    filename = secure_filename(file.filename)
+    ext = os.path.splitext(filename)[1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        return None, "Formato immagine non supportato"
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    limit = current_app.config.get("MAX_CONTENT_LENGTH", MAX_UPLOAD_SIZE)
+    if size > limit:
+        return None, "File troppo grande"
+    return filename, None
 
 
 # --- FUNZIONI DI CARICAMENTO MODELLI ---
@@ -298,6 +314,7 @@ def create_app():
     load_dotenv()
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", os.urandom(24).hex())
     app.config["GEMINI_API_KEY"] = os.getenv("GEMINI_API_KEY")
+    app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_SIZE
 
     csrf = CSRFProtect(app)
     CORS(app, resources={r"/*": {"origins": "*"}})
@@ -401,7 +418,10 @@ def create_app():
         user = request.form.get("user", "guest")
         shared = request.form.get("shared", "false").lower() == "true"
         file = request.files["image"]
-        fname = uuid.uuid4().hex + os.path.splitext(file.filename)[1]
+        filename, err = validate_upload(file)
+        if err:
+            return jsonify({"error": err}), 400
+        fname = uuid.uuid4().hex + os.path.splitext(filename)[1]
 
         user_dir = os.path.join(app.static_folder, "gallery", user)
         os.makedirs(user_dir, exist_ok=True)
@@ -420,7 +440,7 @@ def create_app():
 
         data.append({
             "file": fname,
-            "title": os.path.splitext(file.filename)[0],
+            "title": os.path.splitext(filename)[0],
             "shared": shared
         })
         with open(meta_path, "w", encoding="utf-8") as f:
@@ -454,9 +474,12 @@ def create_app():
         try:
             if "subject_image" not in request.files:
                 return jsonify(error="Immagine soggetto mancante."), 400
+            file = request.files["subject_image"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify(error=err), 400
             subject = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["subject_image"].read())).convert("RGBA"))
+                Image.open(io.BytesIO(file.read())).convert("RGBA"))
             processed = remove(subject)
             buf = io.BytesIO()
             processed.save(buf, format="PNG")
@@ -473,9 +496,12 @@ def create_app():
             if "subject_data" not in request.files or "prompt" not in request.form:
                 return jsonify(error="Dati mancanti"), 400
             ensure_pipeline_is_loaded()
+            file = request.files["subject_data"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify(error=err), 400
             subject = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["subject_data"].read())).convert("RGB"))
+                Image.open(io.BytesIO(file.read())).convert("RGB"))
             mask = remove(subject, only_mask=True, post_process_mask=True)
             mask = ImageOps.invert(mask.convert("L"))
             canny_map = canny_detector(subject,
@@ -517,9 +543,12 @@ def create_app():
                                             "true").lower() == "true"
             denoise = float(request.form.get("tile_denoising_strength", 0.3))
             ensure_pipeline_is_loaded()
+            file = request.files["scene_image"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify(error=err), 400
             scene = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["scene_image"].read())).convert("RGB"))
+                Image.open(io.BytesIO(file.read())).convert("RGB"))
             if enable_hires:
                 model = RRDBNet(
                     num_in_ch=3,
@@ -670,9 +699,12 @@ def create_app():
             if "image" not in request.files:
                 return jsonify(error="Missing image"), 400
             ensure_yolo_parser_is_loaded()
+            file = request.files["image"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify(error=err), 400
             image_pil = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["image"].read())).convert("RGB"))
+                Image.open(io.BytesIO(file.read())).convert("RGB"))
             results = yolo_parser(image_pil)[0]
             return jsonify(parts=sorted(
                 list(
@@ -697,9 +729,12 @@ def create_app():
             ensure_sam_predictor_is_loaded()
 
             prompts = json.loads(request.form.get("prompts"))
+            file = request.files["image"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify(error=err), 400
             current_image = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["image"].read())).convert("RGB"))
+                Image.open(io.BytesIO(file.read())).convert("RGB"))
 
             for part_name, prompt_text in prompts.items():
                 if not prompt_text:
@@ -760,9 +795,12 @@ def create_app():
             if "image" not in request.files:
                 return jsonify({"error": "Immagine mancante."}), 400
             ensure_face_analyzer_is_loaded()
+            file = request.files["image"]
+            _, err = validate_upload(file)
+            if err:
+                return jsonify({"error": err}), 400
             image_pil = normalize_image(
-                Image.open(io.BytesIO(
-                    request.files["image"].read())).convert("RGB"))
+                Image.open(io.BytesIO(file.read())).convert("RGB"))
             image_np = cv2.cvtColor(np.array(image_pil), cv2.COLOR_RGB2BGR)
             faces = face_analyzer.get(image_np)
             return jsonify({
@@ -788,15 +826,16 @@ def create_app():
             ensure_face_analyzer_is_loaded()
             ensure_face_swapper_is_loaded()
             ensure_face_restorer_is_loaded()
+            tgt_file = request.files["target_image_high_res"]
+            src_file = request.files["source_face_image"]
+            for f in (tgt_file, src_file):
+                _, err = validate_upload(f)
+                if err:
+                    return jsonify(error=err), 400
             target_pil = normalize_image(
-                Image.open(
-                    io.BytesIO(request.files["target_image_high_res"].read())).
-                convert("RGB"))
+                Image.open(io.BytesIO(tgt_file.read())).convert("RGB"))
             source_pil = normalize_image(
-                Image.open(
-                    io.BytesIO(
-                        request.files["source_face_image"].read())).convert(
-                            "RGB"))
+                Image.open(io.BytesIO(src_file.read())).convert("RGB"))
             target_img_cv = cv2.cvtColor(np.array(target_pil),
                                          cv2.COLOR_RGB2BGR)
             source_img_cv = cv2.cvtColor(np.array(source_pil),


### PR DESCRIPTION
## Summary
- secure uploaded image filenames and limit extensions
- validate uploaded file sizes and enforce max content length
- integrate upload checks into meme and processing routes
- set Flask `MAX_CONTENT_LENGTH`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ba2701b4832981af9bd6960723de