### PR TITLE
Fix gallery upload auth check

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -398,7 +398,10 @@ def create_app():
         if "image" not in request.files:
             return jsonify({"error": "Immagine mancante"}), 400
 
-        user = request.form.get("user", "guest")
+        session_user = session.get("user_id")
+        user = request.form.get("user", session_user or "guest")
+        if user != session_user:
+            return jsonify({"error": "Forbidden"}), 403
         shared = request.form.get("shared", "false").lower() == "true"
         file = request.files["image"]
         fname = uuid.uuid4().hex + os.path.splitext(file.filename)[1]


### PR DESCRIPTION
## Summary
- ensure gallery upload uses the logged-in user

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850ba2a5afc8329bf04cececdd5a6c1