### PR TITLE
Add model selection UI

### DIFF
--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -1,5 +1,5 @@
 import os
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 MODEL_DIR = os.path.join("models", "checkpoints")
 ACTIVE_MODEL_FILE = os.path.join("models", "active_model.txt")
@@ -14,9 +14,35 @@ def scan_available_models():
     )
 
 
+def get_active_model():
+    if os.path.isfile(ACTIVE_MODEL_FILE):
+        try:
+            with open(ACTIVE_MODEL_FILE, "r", encoding="utf-8") as f:
+                name = f.read().strip()
+                if name:
+                    return name
+        except Exception:
+            pass
+    return None
+
+
 model_bp = Blueprint("model_manager", __name__, url_prefix="/api/models")
 
 
 @model_bp.route("/list", methods=["GET"])
 def list_models():
-    return jsonify(scan_available_models())
+    return jsonify({"models": scan_available_models(), "active": get_active_model()})
+
+
+@model_bp.route("/activate", methods=["POST"])
+def activate_model():
+    data = request.get_json() or {}
+    model_name = data.get("model_name")
+    if not model_name:
+        return jsonify({"error": "model_name required"}), 400
+    if model_name not in scan_available_models():
+        return jsonify({"error": "model not found"}), 404
+    os.makedirs(os.path.dirname(ACTIVE_MODEL_FILE), exist_ok=True)
+    with open(ACTIVE_MODEL_FILE, "w", encoding="utf-8") as f:
+        f.write(model_name)
+    return jsonify({"active_model": model_name})

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -46,10 +46,11 @@ export async function getStickers() {
     return response.json();
 }
 
-export async function createSceneAsync(processedSubjectBlob, finalPrompt) {
+export async function createSceneAsync(processedSubjectBlob, finalPrompt, modelName) {
     const formData = new FormData();
     formData.append('subject_data', processedSubjectBlob);
     formData.append('prompt', finalPrompt);
+    if (modelName) formData.append('model_name', modelName);
 
     // Chiama la nuova rotta asincrona
     const response = await csrfFetch(`${BASE_URL}/async/create_scene`, { method: 'POST', body: formData });
@@ -65,10 +66,11 @@ export async function prepareSubject(subjectFile) {
     return response.blob();
 }
 
-export async function createScene(processedSubjectBlob, finalPrompt) {
+export async function createScene(processedSubjectBlob, finalPrompt, modelName) {
     const formData = new FormData();
     formData.append('subject_data', processedSubjectBlob);
     formData.append('prompt', finalPrompt);
+    if (modelName) formData.append('model_name', modelName);
     const response = await csrfFetch(`${BASE_URL}/create_scene`, { method: 'POST', body: formData, cache: 'no-cache' });
     await handleResponse(response);
     return response.blob();

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,6 +1,6 @@
 import { assignDomElements, dom } from './state.js';
 import { initTheme } from './theme.js';
-import { setupEventListeners, resetWorkflow, closeModal } from './workflow.js';
+import { setupEventListeners, resetWorkflow, closeModal, loadAvailableModels } from './workflow.js';
 import { initFaceBoxObservers } from './facebox.js';
 import { loadStickers } from './stickers.js';
 import { animationLoop } from './memeEditor.js';
@@ -9,6 +9,7 @@ import { loadGallery, setupGalleryInteraction, initSidebarToggle } from './galle
 document.addEventListener('DOMContentLoaded', () => {
   assignDomElements();
   initFaceBoxObservers();
+  loadAvailableModels();
   initTheme(dom.themeToggle, dom.themeIcon);
   initSidebarToggle(dom.sidebar, dom.sidebarToggle);
   setupEventListeners();

--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -30,7 +30,7 @@ export function assignDomElements() {
     'download-btn', 'add-gallery-btn', 'download-anim-btn', 'anim-fmt', 'share-btn', 'reset-all-btn',
     'step-1-subject', 'fileInput', 'imagePreview', 'subject-upload-prompt',
     'prepare-subject-btn', 'skip-to-swap-btn',
-    'step-2-scene', 'bg-prompt-input', 'auto-enhance-prompt-toggle', 'generate-scene-btn', 'goto-step-3-btn',
+    'step-2-scene', 'bg-prompt-input', 'auto-enhance-prompt-toggle', 'model-selector', 'generate-scene-btn', 'goto-step-3-btn',
     'step-3-upscale', 'enable-hires-upscale-toggle', 'tile-denoising-slider', 'tile-denoising-value',
     'start-upscale-btn', 'skip-upscale-btn',
     'step-4-finalize', 'source-img-input', 'source-img-preview', 'source-upload-prompt',

--- a/app/static/js/workflow.js
+++ b/app/static/js/workflow.js
@@ -90,6 +90,29 @@ export function goToStep(stepNumber) {
   document.getElementById(stepId)?.classList.remove('hidden');
 }
 
+export async function loadAvailableModels() {
+  if (!dom.modelSelector) return;
+  try {
+    const res = await fetch('/api/models/list');
+    const data = await res.json();
+    const models = data.models || data;
+    const active = data.active;
+    dom.modelSelector.innerHTML = '';
+    models.forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      if (name === active) opt.selected = true;
+      dom.modelSelector.appendChild(opt);
+    });
+    if (!dom.modelSelector.value && models.length > 0) {
+      dom.modelSelector.value = models[0];
+    }
+  } catch (err) {
+    console.error('Errore caricamento modelli', err);
+  }
+}
+
 export function handleSubjectFile(file) {
   if (!file?.type.startsWith('image/')) return;
   state.subjectFile = file;
@@ -199,7 +222,8 @@ export async function handleCreateScene() {
             dom.bgPromptInput.value = prompt;
             finishProgressBar();
         }
-        const taskInfo = await api.createSceneAsync(state.processedSubjectBlob, prompt);
+        const model = dom.modelSelector ? dom.modelSelector.value : undefined;
+        const taskInfo = await api.createSceneAsync(state.processedSubjectBlob, prompt, model);
         const resultBlob = await pollTask(taskInfo.task_id, '🎨 Creazione Scena AI in corso...');
         state.sceneImageBlob = resultBlob;
         state.finalImageWithSwap = null;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,6 +61,10 @@
                         <label for="auto-enhance-prompt-toggle" class="toggle-bg w-10 h-5 bg-gray-600 rounded-full"><div class="toggle-dot absolute w-4 h-4 bg-white rounded-full shadow top-0.5 left-0.5 transition-transform"></div></label>
                     </div>
                 </div>
+                <div class="mb-4">
+                    <label for="model-selector" class="block mb-2 text-sm font-medium text-gray-400">Modello di generazione</label>
+                    <select id="model-selector" class="w-full bg-gray-700 border border-gray-600 rounded-lg p-2 text-gray-300"></select>
+                </div>
                 <button id="generate-scene-btn" class="btn btn-primary w-full mt-2 text-white font-bold py-2 px-4 rounded-lg">🎨 Genera Sfondo e Componi Scena</button>
             </div>
             <button id="goto-step-3-btn" class="btn btn-secondary w-full mt-4 text-white font-bold py-3 px-4 rounded-lg disabled:opacity-50" disabled>Vai allo Step 3: Upscale</button>


### PR DESCRIPTION
## Summary
- add dropdown to choose SDXL model in scene generation step
- fetch available models on page load and preselect active one
- send selected model to backend when creating a scene
- register `model-selector` DOM element in state
- expose `/api/models/activate` and improved `/api/models/list`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68528b407a5c83299efc235c14df8c01